### PR TITLE
Spelling patches submitted from Debian

### DIFF
--- a/lib/UR/Context/Process.pm
+++ b/lib/UR/Context/Process.pm
@@ -35,7 +35,7 @@ UR::Context::Process - Impliments a generic interface to the current application
 
 =head1 DESCRIPTION
 
-This module provides methods to set and retreive variaous names
+This module provides methods to set and retrieve various names
 associated with the program and the program version number.
 
 =cut

--- a/lib/UR/DataSource/Oracle.pm
+++ b/lib/UR/DataSource/Oracle.pm
@@ -226,7 +226,7 @@ sub set_userenv {
 sub get_userenv {
 
     # there are two ways to set these values but this is
-    # the only way to retreive the values after they are set
+    # the only way to retrieve the values after they are set
 
     my ($self, $dbh) = @_;
 


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=85982

Change-Id: I8ffc89b8607cda010dde5d8a27e777f509ee13d3
Description: fix a spelling mistake
Origin: vendor
Author: gregor herrmann gregoa@debian.org
Last-Update: 2013-06-08
