### PR TITLE
Don't let Term::ANSIColor polute our namespace

### DIFF
--- a/lib/Command/V1.pm
+++ b/lib/Command/V1.pm
@@ -7,7 +7,7 @@ use UR;
 use Data::Dumper;
 use File::Basename;
 use Getopt::Long;
-use Term::ANSIColor;
+use Term::ANSIColor qw();
 require Text::Wrap;
 
 our $VERSION = "0.43"; # UR $VERSION;

--- a/lib/Command/View/DocMethods.pm
+++ b/lib/Command/View/DocMethods.pm
@@ -2,7 +2,7 @@ package Command::V2;  # additional methods to produce documentation, TODO: turn 
 use strict;
 use warnings;
 
-use Term::ANSIColor;
+use Term::ANSIColor qw();
 use Pod::Simple::Text;
 require Text::Wrap;
 


### PR DESCRIPTION
This was leading to the cryptic error message:

ERROR: Invalid attribute name genome::model::build::command::view=hash(0x6cf8ba8) at /gscuser/dmorton/deployments/bases_for_sample/genome/ur/lib/UR/Object.pm line 192

when an attribute named 'color' was inherited and not redefined in the derived class.
