### PR TITLE
Order by

### DIFF
--- a/lib/UR/BoolExpr.pm
+++ b/lib/UR/BoolExpr.pm
@@ -459,7 +459,7 @@ sub resolve {
             Carp::croak("Can't resolve BoolExpr: undef is an invalid key/property name.  Args were: ".join(', ',@in_params));
         }
 
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             # these are keys whose values live in the rule template
             push @keys, $key;
             push @constant_values, $value;
@@ -560,7 +560,7 @@ sub resolve {
 
     for my $value (@values) {
         $key = $keys[$kn++];
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             $cn++;
             redo;
         }
@@ -815,7 +815,7 @@ sub resolve {
     my @list;
     for my $key (@keys) {
         push @list, $key;
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             push @list, $constant_values[$cn++];
         }
         else {
@@ -855,7 +855,7 @@ sub _params_list {
             my $cn = 0;
             for my $key (@$k) {
                 push @list, $key;
-                if (substr($key,0,1) eq '-') {
+                if (UR::BoolExpr::Util::is_meta_param($key)) {
                     push @list, $c->[$cn++];
                 }
                 else {

--- a/lib/UR/BoolExpr/Template.pm
+++ b/lib/UR/BoolExpr/Template.pm
@@ -424,10 +424,6 @@ sub get_by_subject_class_name_logic_type_and_logic_detail {
     return $class->get(join('/',$subject_class_name,$logic_type,$logic_detail,$constant_value_id));
 }
 
-sub _is_meta_param {
-    return substr(shift, 0, 1) eq '-';
-}
-
 # The analogue of resolve in UR::BoolExpr.  @params_list is a list if
 # strings containing properties and operators separated by a space.  For ex: "some_param ="
 sub resolve {
@@ -436,7 +432,7 @@ sub resolve {
     my(@params, @constant_values);
     for (my $i = 0; $i < @params_list; $i++) {
         push @params, $params_list[$i];
-        if (_is_meta_param($params_list[$i])) {
+        if (UR::BoolExpr::Util::is_meta_param($params_list[$i])) {
             push @constant_values, $params_list[++$i];
         }
     }

--- a/lib/UR/BoolExpr/Template.pm
+++ b/lib/UR/BoolExpr/Template.pm
@@ -412,8 +412,6 @@ sub sub_classify {
 
 # flyweight constructor
 # NOTE: this caches outside of the regular system since these are stateless objects
-# NOTE: It's not possible to use this to construct a template with meta-props, like
-# -hints or -order.  To do that, it'll have to also accept constant values as an arg
 sub get_by_subject_class_name_logic_type_and_logic_detail {
     my $class = shift;
     my $subject_class_name = shift;
@@ -421,18 +419,33 @@ sub get_by_subject_class_name_logic_type_and_logic_detail {
                     . ( defined($subject_class_name) ? "'$subject_class_name'" : "(undef)" ) ) unless ($subject_class_name);
     my $logic_type = shift;
     my $logic_detail = shift;
+    my $constant_value_id = shift || UR::BoolExpr::Util::values_to_value_id(); # default is an empty list of values
 
-    my $constant_value_id = UR::BoolExpr::Util::values_to_value_id(); # intentionally an empty list of values
     return $class->get(join('/',$subject_class_name,$logic_type,$logic_detail,$constant_value_id));
 }
 
+sub _is_meta_param {
+    return substr(shift, 0, 1) eq '-';
+}
 
 # The analogue of resolve in UR::BoolExpr.  @params_list is a list if
 # strings containing properties and operators separated by a space.  For ex: "some_param ="
 sub resolve {
     my($class,$subject_class_name, @params_list) = @_;
 
-    return $class->get_by_subject_class_name_logic_type_and_logic_detail($subject_class_name, "And", join(',',@params_list));
+    my(@params, @constant_values);
+    for (my $i = 0; $i < @params_list; $i++) {
+        push @params, $params_list[$i];
+        if (_is_meta_param($params_list[$i])) {
+            push @constant_values, $params_list[++$i];
+        }
+    }
+
+    return $class->get_by_subject_class_name_logic_type_and_logic_detail(
+                        $subject_class_name,
+                        "And",
+                        join(',',@params),
+                        UR::BoolExpr::Util::values_to_value_id(@constant_values));
 }
 
 sub get {

--- a/lib/UR/BoolExpr/Template/And.pm
+++ b/lib/UR/BoolExpr/Template/And.pm
@@ -489,7 +489,7 @@ sub params_list_for_values {
             my ($property, $op) = ($key =~ /^(\-*[\w\.]+)\s*(.*)$/);        
             unless ($property) {
                 $DB::single = 1;
-                Carp::confess("bad key $key in @keys_sorted");
+                Carp::confess("bad key '$key' in ",join(', ', @keys_sorted));
             }
             my $value = $values_sorted[$v];
             if ($op) {

--- a/lib/UR/BoolExpr/Template/And.pm
+++ b/lib/UR/BoolExpr/Template/And.pm
@@ -66,7 +66,7 @@ sub _flatten {
     while (my $key = shift @old_keys) {
         my $name = $key;
         $name =~ s/ .*//;
-        if (substr($name,0,1) ne '-') {
+        if (! UR::BoolExpr::Util::is_meta_param($name)) {
             my $mdata = $old_property_meta_hash->{$name};
             my ($value_position, $operator) = @$mdata{'value_position','operator'};
             
@@ -265,7 +265,7 @@ sub _reframe {
     while (@old_keys) {
         my $old_key = shift @old_keys;
 
-        if (substr($old_key,0,1) ne '-') {
+        if (! UR::BoolExpr::Util::is_meta_param($old_key)) {
             # a regular property
             my $old_name = $old_key;
             $old_name =~ s/ .*//;
@@ -367,7 +367,7 @@ sub _underlying_keys {
 
 sub get_underlying_rule_templates {
     my $self = shift;
-    my @underlying_keys = grep { substr($_,0,1) eq '-' ? () : ($_) } $self->_underlying_keys();
+    my @underlying_keys = grep { UR::BoolExpr::Util::is_meta_param($_) ? () : ($_) } $self->_underlying_keys();
     my $subject_class_name = $self->subject_class_name;
     return map {                
             UR::BoolExpr::Template::PropertyComparison
@@ -480,8 +480,7 @@ sub params_list_for_values {
         #if (substr($key,0,1) eq "_") {
         #    next;
         #}
-        #elsif (substr($key,0,1) eq '-') {
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             my $value = $constant_values->[$c];
             push @params, $key, $value;        
             $c++;
@@ -560,7 +559,7 @@ sub _fast_construct {
     no warnings; 
     my %check_for_duplicate_rules;
     for (my $n=0; $n < @keys; $n++) {
-        next if (substr($keys[$n],0,1) eq '-');
+        next if UR::BoolExpr::Util::is_meta_param($keys[$n]);
         my $pos = index($keys[$n],' ');
         if ($pos != -1) {
             my $property = substr($keys[$n],0,$pos);
@@ -587,7 +586,7 @@ sub _fast_construct {
     my $property_meta_hash = {};        
     my $property_names = [];
     for my $key (@keys) {
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             $property_meta_hash->{$key} = {
                 name => $key,
                 value_position => $const_pos
@@ -630,7 +629,7 @@ sub _fast_construct {
         my $values_index = -1; # -1 so we can bump it at start of loop
         for (my $key_pos = 0; $key_pos < $original_key_count; $key_pos++) {
             my $key = $keys[$key_pos];
-            if (substr($key, 0, 1) eq '-') {
+            if (UR::BoolExpr::Util::is_meta_param($key)) {
                 # -* are constant value keys and do not need to be changed
                 next;
             } else {
@@ -660,7 +659,7 @@ sub _fast_construct {
                     $id_only = 0;
                 }
             }    
-            elsif (substr($key,0,1) ne '-') {
+            elsif (! UR::BoolExpr::Util::is_meta_param($key)) {
                 $id_only = 0;
                 ## print "non id single property $property on $subject_class\n";
             }
@@ -675,13 +674,13 @@ sub _fast_construct {
         my $id_op;
         for (my $key_pos = 0; $key_pos < $original_key_count; $key_pos++) {
             my $key = $keys[$key_pos];
-            if (substr($key, 0, 1) eq '-') {
+            if (UR::BoolExpr::Util::is_meta_param($key)) {
                 # -* are constant value keys and do not need to be changed
                 next;
             } else {
                 $values_index++;
             }
-            next if substr($key,0,1) eq '-';
+            next if UR::BoolExpr::Util::is_meta_param($key);
 
             my ($property, $op) = ($key =~ /^(.+?)\s+(.*)$/);
             $property ||= $key;
@@ -770,7 +769,7 @@ sub _fast_construct {
     my $cpos = 0;
     for my $key (@keys) {
         $key_positions{$key} ||= [];
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             push @{ $key_positions{$key} }, $cpos++;    
         }
         else {
@@ -799,7 +798,7 @@ sub _fast_construct {
     for my $key (@keys_sorted) {
         my $pos_list = $key_positions{$key};
         my $pos = pop @$pos_list;
-        if (substr($key,0,1) eq '-') {
+        if (UR::BoolExpr::Util::is_meta_param($key)) {
             push @$constant_value_normalized_positions, $pos;
             my $constant_value = $constant_values[$pos];
 
@@ -875,7 +874,7 @@ sub _fast_construct {
     my @ambiguous_keys;
     my @ambiguous_property_names;
     for (my $n=0; $n < @keys; $n++) {
-        next if substr($keys[$n],0,1) eq '-';
+        next if UR::BoolExpr::Util::is_meta_param($keys[$n]);
         my ($property, $op) = ($keys[$n] =~ /^(.+?)\s+(.*)$/);
         $property ||= $keys[$n];
         $op ||= '';
@@ -893,7 +892,7 @@ sub _fast_construct {
 
     my @keys_unaliased = $UR::Object::Type::bootstrapping
                             ? @keys_sorted
-                            : map { $_->[0] = substr($_->[0], 0, 1) eq '-' ? $_->[0] : $subject_class_meta->resolve_property_aliases($_->[0]);
+                            : map { $_->[0] = UR::BoolExpr::Util::is_meta_param($_->[0]) ? $_->[0] : $subject_class_meta->resolve_property_aliases($_->[0]);
                                     join(' ',@$_); }
                                 map { [ split(' ') ] }
                                 @keys_sorted;

--- a/lib/UR/BoolExpr/Util.pm
+++ b/lib/UR/BoolExpr/Util.pm
@@ -184,6 +184,11 @@ sub value_id_to_values {
     return @values;
 }
 
+sub is_meta_param {
+    my $param_name = shift;
+    return substr($param_name, 0, 1) eq '-';
+}
+
 package UR::BoolExpr::Util::clonedThing;
 
 sub bless {

--- a/lib/UR/Manual/Overview.pod
+++ b/lib/UR/Manual/Overview.pod
@@ -199,7 +199,7 @@ directly to the database
 
 =back
 
-Unloading objects from the cache han be done in several ways
+Unloading objects from the cache can be done in several ways
 
 =over 4
 

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -400,34 +400,34 @@ sub _resolve_bridge_logic_for_indirect_property {
             my @my_values = map { $self->$_} @my_join_properties;
             my $bx = $bridge_template->get_rule_for_values(@my_values, @where_values);
             return $bridge_class->get($bx);
-         };
+        };
 
-         if($to_property_meta->is_delegated and $to_property_meta->via) {
-             # It's a "normal" doubly delegated property
-             my $second_via_property_meta = $to_property_meta->via_property_meta;
-             my $final_class_name = $second_via_property_meta->data_type;
+        if ($to_property_meta->is_delegated and $to_property_meta->via) {
+            # It's a "normal" doubly delegated property
+            my $second_via_property_meta = $to_property_meta->via_property_meta;
+            my $final_class_name = $second_via_property_meta->data_type;
 
-             if ($final_class_name and $final_class_name ne 'UR::Value' and $final_class_name->isa('UR::Object')) {
-                 my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join;
-                 if (@via2_join_properties > 1) {
-                     Carp::carp("via2 join not implemented :(");
-                     return;
-                 }
-                 my($my_property_name,$their_property_name) = @{ $via2_join_properties[0] };
-                 my $crosser_template = UR::BoolExpr::Template->resolve($final_class_name, "$their_property_name in");
+            if ($final_class_name and $final_class_name ne 'UR::Value' and $final_class_name->isa('UR::Object')) {
+                my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join;
+                if (@via2_join_properties > 1) {
+                    Carp::carp("via2 join not implemented :(");
+                    return;
+                }
+                my($my_property_name,$their_property_name) = @{ $via2_join_properties[0] };
+                my $crosser_template = UR::BoolExpr::Template->resolve($final_class_name, "$their_property_name in");
 
-                 my $result_property_name = $to_property_meta->to;
+                my $result_property_name = $to_property_meta->to;
 
-                 $bridge_crosser = sub {
-                     my $bridges = shift;
-                     my @linking_values = map { $_->$my_property_name } @$bridges;
-                     my $bx = $crosser_template->get_rule_for_values(\@linking_values);
-                     my @result_objects = (@_ ? $final_class_name->get($bx->params_list, @_) : $final_class_name->get($bx) );
-                     return map { $_->$result_property_name } @result_objects;
-                 };
-             }
+                $bridge_crosser = sub {
+                    my $bridges = shift;
+                    my @linking_values = map { $_->$my_property_name } @$bridges;
+                    my $bx = $crosser_template->get_rule_for_values(\@linking_values);
+                    my @result_objects = (@_ ? $final_class_name->get($bx->params_list, @_) : $final_class_name->get($bx) );
+                    return map { $_->$result_property_name } @result_objects;
+                };
+            }
 
-         } elsif ($to_property_meta->id_by and $to_property_meta->id_class_by) {
+        } elsif ($to_property_meta->id_by and $to_property_meta->id_class_by) {
             # Bridging through an 'id_class_by' property
             # bucket the bridge items by the result class and do a get for
             # each of those classes with a listref of IDs

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -524,16 +524,14 @@ sub _resolve_bridge_logic_for_indirect_property {
                     my $results_sorter = $make_results_sorter->(
                                             $bridges,
                                             sub { my $bridge = $_;
-                                                  UR::BoolExpr::Util::values_to_value_id(
-                                                      map { $bridge->$_ } @my_join_properties
+                                                  $id_resolver->(
+                                                      map { $bridge->$_ } @{ $to_property_meta->id_by }
                                                   );
                                             },
                                             sub { my $result = $_;
-                                                  UR::BoolExpr::Util::values_to_value_id(
-                                                      map { $result->$_ } @their_join_properties
-                                                  );
+                                                  $_->id;
                                             } );
-                    @results = $results_sorter->($bridges, \@results);
+                    @results = $results_sorter->(\@results);
                 }
                 return @results;
             }

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -507,12 +507,12 @@ sub _resolve_bridge_logic_for_indirect_property {
         } elsif ($to_property_meta->id_by and $to_property_meta->data_type and not $to_property_meta->data_type->isa('UR::Value')) {
             my $result_class = $to_property_meta->data_type;
             my $bridging_identifiers = $to_property_meta->id_by;
+            my $id_resolver = $result_class->__meta__->get_composite_id_resolver;
 
             $bridge_crosser = sub {
                 my $bridges = shift;
                 my @ids;
                 foreach my $bridge ( @$bridges ) {
-                    my $id_resolver = $result_class->__meta__->get_composite_id_resolver;
                     my @id = map { $bridge->$_ } @$bridging_identifiers;
                     my $id = $id_resolver->(@id);
 

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -378,21 +378,20 @@ sub _resolve_bridge_logic_for_indirect_property {
             while (@collected_where) {
                 my $where_property = shift @collected_where;
                 my $where_value = shift @collected_where;
-                # FIXME Skip stuff like -hints and -order_by until UR::BE::Template->resolve() can handle them
-                next if (substr($where_property, 0, 1) eq '-');
                 if (ref($where_value) eq 'HASH' and $where_value->{'operator'}) {
                     $where_property .= ' ' .$where_value->{'operator'};
                     $where_value = $where_value->{'value'};
                 }
                 push @where_properties, $where_property;
-                push @where_values, $where_value;
+
+                if (substr($where_property, 0, 1) eq '-') {
+                    push @where_properties, $where_value;
+                } else {
+                    push @where_values, $where_value;
+                }
             }
         }
 
-        #my $bridge_template = UR::BoolExpr::Template->resolve($bridge_class,
-        #                                                      @their_join_properties,
-        #                                                      @where_properties,
-        #                                                      -hints => [$via_property_meta->to]);
         my $bridge_template = UR::BoolExpr::Template->resolve($bridge_class, @their_join_properties, @where_properties);
 
         $bridge_collector = sub {

--- a/t/URT/t/56c_via_property_with_order_by.t
+++ b/t/URT/t/56c_via_property_with_order_by.t
@@ -56,8 +56,9 @@ subtest 'in database' => sub {
     foreach my $val ( [ 99,  $thing_id, 'favorite', 4, 4 ],
                       [ 100, $thing_id, 'favorite', 2, 2 ],
                       [ 101, $thing_id, 'favorite', 6, 6 ],
-                      [ 102, $thing_id, 'favorite', 1, 1 ],
-                      [ 103, $thing_id, 'name', 1, 'Fred' ],
+                      [ 102, $thing_id, 'favorite', 2, 2 ],
+                      [ 103, $thing_id, 'favorite', 1, 1 ],
+                      [ 104, $thing_id, 'name', 1, 'Fred' ],
     ) {
         $insert->execute(@$val);
     }
@@ -66,7 +67,7 @@ subtest 'in database' => sub {
     my @favorites = $thing->favorites();
     is_deeply(
         \@favorites,
-        [ 1, 2, 4, 6],
+        [ 1, 2, 2, 4, 6],
         'Got back ordered favorites');
 };
 
@@ -75,12 +76,12 @@ subtest 'in-memory' => sub {
 
     my $thing = Thing->create();
     Attribute->create(thing_id => $thing->id, key => 'name', value => 'Bob', rank => 1);
-    Attribute->create(thing_id => $thing->id, key => 'favorite', value => $_, rank => $_) foreach (qw( 4 2 6 1 ));
+    Attribute->create(thing_id => $thing->id, key => 'favorite', value => $_, rank => $_) foreach (qw( 4 2 6 2 1 ));
 
     my @favorites = $thing->favorites();
     is_deeply(
         \@favorites,
-        [1, 2, 4, 6],
+        [1, 2, 2, 4, 6],
         'Got back ordered favorites');
 };
 
@@ -112,7 +113,7 @@ subtest '"to" is via-to' => sub {
     # make a Thing with favorites 1, 2, 4 and 6, ranked in numerical order
     # but their IDs are not sorted the same as their values/ranks
     my $thing = ViaThing->create();
-    my @value_objs = map { ViaValue->create(value => $_) } (qw( 4 2 6 1));
+    my @value_objs = map { ViaValue->create(value => $_) } (qw( 4 2 6 2 1));
     my @attrib_objs = map { ViaAttribute->create(
                                     thing_id => $thing->id,
                                     key => 'favorite',

--- a/t/URT/t/56c_via_property_with_order_by.t
+++ b/t/URT/t/56c_via_property_with_order_by.t
@@ -1,0 +1,90 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Basename;
+use lib File::Basename::dirname(__FILE__)."/../../../lib";
+use lib File::Basename::dirname(__FILE__)."/../..";
+use URT;
+use Test::More tests => 2;
+
+# A thing has many attributes, which are ordered and have names
+UR::Object::Type->define(
+    class_name => 'Thing',
+    id_by => 'thing_id',
+    has_many => [
+        attribs => {
+            is => 'Attribute',
+            reverse_as => 'thing',
+        },
+        favorites => {
+            via => 'attribs',
+            where => [ key => 'favorite', '-order_by' => 'rank' ],
+            to => 'value',
+        },
+    ],
+    data_source => 'URT::DataSource::SomeSQLite',
+    table_name => 'things',
+);
+
+UR::Object::Type->define(
+    class_name => 'Attribute',
+    id_by => 'attrib_id',
+    has => [
+        thing => { is => 'Thing', id_by => 'thing_id' },
+        key => { is => 'String' },
+        rank => { is => 'Integer' },
+        value => { is => 'String' },
+    ],
+    data_source => 'URT::DataSource::SomeSQLite',
+    table_name => 'attribs',
+);
+
+my $bx = Attribute->define_boolexpr(thing_id => 'foo', key => 'foo', -order_by => 'rank');
+my $tmpl = $bx->template;
+print "*** Constructed tmpl: ",Data::Dumper::Dumper($tmpl);
+
+subtest 'in database' => sub {
+    plan tests => 3;
+
+    my $thing_id = 99;
+
+    my $dbh = URT::DataSource::SomeSQLite->get_default_handle();
+    ok($dbh->do('create table things (thing_id integer NOT NULL PRIMARY KEY)'),
+        'create table things');
+    ok($dbh->do('create table attribs (attrib_id integer NOT NULL PRIMARY KEY, thing_id INTEGER REFERENCES things(thing_id), key VARCHAR NOT NULL, rank INTEGER NOT NULL, value VARCHAR)'),
+        'create table attributes');
+
+    $dbh->do("insert into things values ($thing_id)");
+
+    my $insert = $dbh->prepare('insert into attribs values (?,?,?,?,?)');
+    foreach my $val ( [ 99,  $thing_id, 'favorite', 4, 4 ],
+                      [ 100, $thing_id, 'favorite', 2, 2 ],
+                      [ 101, $thing_id, 'favorite', 6, 6 ],
+                      [ 102, $thing_id, 'favorite', 1, 1 ],
+                      [ 103, $thing_id, 'name', 1, 'Fred' ],
+    ) {
+        $insert->execute(@$val);
+    }
+
+    my $thing = Thing->get($thing_id);
+    my @favorites = $thing->favorites();
+    is_deeply(
+        \@favorites,
+        [ 1, 2, 4, 6],
+        'Got back ordered favorites');
+};
+
+subtest 'in-memory' => sub {
+    plan tests => 1;
+
+    my $thing = Thing->create();
+    Attribute->create(thing_id => $thing->id, key => 'name', value => 'Bob', rank => 1);
+    Attribute->create(thing_id => $thing->id, key => 'favorite', value => $_, rank => $_) foreach (qw( 4 2 6 1 ));
+
+    my @favorites = $thing->favorites();
+    is_deeply(
+        \@favorites,
+        [1, 2, 4, 6],
+        'Got back ordered favorites');
+};
+

--- a/t/URT/t/56c_via_property_with_order_by.t
+++ b/t/URT/t/56c_via_property_with_order_by.t
@@ -39,10 +39,6 @@ UR::Object::Type->define(
     table_name => 'attribs',
 );
 
-my $bx = Attribute->define_boolexpr(thing_id => 'foo', key => 'foo', -order_by => 'rank');
-my $tmpl = $bx->template;
-print "*** Constructed tmpl: ",Data::Dumper::Dumper($tmpl);
-
 subtest 'in database' => sub {
     plan tests => 3;
 


### PR DESCRIPTION
UR::BoolExpr::Template->resolve() now accepts params like -order_by => [ 'foo' ].  This allows using
meta-params in the where clause of a delegated property.

This fixes #45 