### PR TITLE
check for cwd() failures

### DIFF
--- a/lib/above.pm
+++ b/lib/above.pm
@@ -3,7 +3,7 @@ package above;
 use strict;
 use warnings;
 
-use Cwd qw(cwd);
+use Cwd qw(getcwd);
 use File::Spec qw();
 
 our $VERSION = '0.03'; # No BumpVersion
@@ -50,7 +50,7 @@ sub use_package {
     }
 
     my $xdev = $ENV{ABOVE_DISCOVERY_ACROSS_FILESYSTEM};
-    my $cwd = cwd();
+    my $cwd = getcwd();
     unless ($cwd) {
         die "cwd failed: $!";
     }


### PR DESCRIPTION
The web server produced 9 GB of this before filling up the disk:

```
Use of uninitialized value $path in stat at /gsc/scripts/opt/genome/snapshots/genome-3545/lib/perl/above.pm line 35.
Use of uninitialized value $dev in numeric eq (==) at /gsc/scripts/opt/genome/snapshots/genome-3545/lib/perl/above.pm line 59.
```
