### PR TITLE
Doubly delegated refactor

### DIFF
--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -419,14 +419,14 @@ sub _resolve_bridge_logic_for_indirect_property {
 
         if ($to_property_meta->is_delegated) {
 
-            my($result_class_resolver, $bridging_identifiers, $final_result_property_name, $result_filtering_property);
+            my($result_class_resolver, $bridge_linking_values, $final_result_property_name, $result_filtering_property);
             if ($to_property_meta->via) {
                 # bridges through another via-to property
                 my $second_via_property_meta = $to_property_meta->via_property_meta;
                 my $final_class_name = $second_via_property_meta->data_type;
                 if ($final_class_name and $final_class_name ne 'UR::Value' and $final_class_name->isa('UR::Object')) {
                     my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join;
-                    $bridging_identifiers = [ map { $_->[0] } @via2_join_properties ];
+                    $bridge_linking_values = [ map { $_->[0] } @via2_join_properties ];
                     $result_filtering_property = $via2_join_properties[0]->[1];
                     $result_class_resolver = sub { $final_class_name };
 
@@ -434,7 +434,7 @@ sub _resolve_bridge_logic_for_indirect_property {
                 }
 
             } elsif ($to_property_meta->id_by) {
-                $bridging_identifiers = $to_property_meta->id_by;
+                $bridge_linking_values = $to_property_meta->id_by;
                 $result_filtering_property = 'id';
                 if ($to_property_meta->id_class_by) {
                     # Bridging through an 'id_class_by' property
@@ -455,7 +455,7 @@ sub _resolve_bridge_logic_for_indirect_property {
 
                 sub {
                     my $bridge = shift;
-                    my @id = map { $bridge->$_ } @$bridging_identifiers;
+                    my @id = map { $bridge->$_ } @$bridge_linking_values;
 
                     my $result_class = $result_class_resolver->($bridge);
                     my $id_resolver = $composite_id_resolver_for_class{ $result_class }

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -457,12 +457,13 @@ sub _resolve_bridge_logic_for_indirect_property {
                 }
 
             } elsif ($to_property_meta->reverse_as) {
-                my @reverse_as_join_properties = $to_property_meta->get_property_name_pairs_for_join;
-                $bridge_linking_properties = [ map { $_->[0] } @reverse_as_join_properties ];
-                $result_filtering_property = $reverse_as_join_properties[0]->[1];
+                if (1 == (my @reverse_as_join_properties = $to_property_meta->get_property_name_pairs_for_join)) {
+                    $bridge_linking_properties = [ map { $_->[0] } @reverse_as_join_properties ];
+                    $result_filtering_property = $reverse_as_join_properties[0]->[1];
 
-                my $result_class = $to_property_meta->data_type;
-                $result_class_resolver = sub { $result_class };
+                    my $result_class = $to_property_meta->data_type;
+                    $result_class_resolver = sub { $result_class };
+                }
             }
 
             my $linking_id_value_for_bridge = do {

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -455,23 +455,25 @@ sub _resolve_bridge_logic_for_indirect_property {
                  ($to_property_meta->id_by and $to_property_meta->data_type and not $to_property_meta->data_type->isa('UR::Value'))
         ) {
 
-            my($result_class_resolver);
-            if ($to_property_meta->id_by and $to_property_meta->id_class_by) {
-                # Bridging through an 'id_class_by' property
-                # bucket the bridge items by the result class and do a get for
-                # each of those classes with a listref of IDs
-                my $result_class_resolving_property = $to_property_meta->id_class_by;
-                $result_class_resolver = sub { shift->$result_class_resolving_property };
+            my($result_class_resolver, $bridging_identifiers);
+            if ($to_property_meta->id_by) {
+                $bridging_identifiers = $to_property_meta->id_by;
+                if ($to_property_meta->id_class_by) {
+                    # Bridging through an 'id_class_by' property
+                    # bucket the bridge items by the result class and do a get for
+                    # each of those classes with a listref of IDs
+                    my $result_class_resolving_property = $to_property_meta->id_class_by;
+                    $result_class_resolver = sub { shift->$result_class_resolving_property };
 
-            } else {
-                # Bridging through a regular id-by property
-                my $result_class = $to_property_meta->data_type;
-                $result_class_resolver = sub { $result_class };
+                } else {
+                    # Bridging through a regular id-by property
+                    my $result_class = $to_property_meta->data_type;
+                    $result_class_resolver = sub { $result_class };
+                }
             }
 
             my $linking_id_value_for_bridge = do {
                 my %composite_id_resolver_for_class;
-                my $bridging_identifiers = $to_property_meta->id_by;
 
                 sub {
                     my $bridge = shift;

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -417,7 +417,7 @@ sub _resolve_bridge_logic_for_indirect_property {
             };
         };
 
-        if ($to_property_meta->is_delegated and ! $to_property_meta->reverse_as) {
+        if ($to_property_meta->is_delegated) {
 
             my($result_class_resolver, $bridge_linking_properties, $final_result_property_name, $result_filtering_property);
             if ($to_property_meta->via) {
@@ -449,6 +449,14 @@ sub _resolve_bridge_logic_for_indirect_property {
                     my $result_class = $to_property_meta->data_type;
                     $result_class_resolver = sub { $result_class };
                 }
+
+            } elsif ($to_property_meta->reverse_as) {
+                my @reverse_as_join_properties = $to_property_meta->get_property_name_pairs_for_join;
+                $bridge_linking_properties = [ map { $_->[0] } @reverse_as_join_properties ];
+                $result_filtering_property = $reverse_as_join_properties[0]->[1];
+
+                my $result_class = $to_property_meta->data_type;
+                $result_class_resolver = sub { $result_class };
             }
 
             my $linking_id_value_for_bridge = do {

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -425,12 +425,13 @@ sub _resolve_bridge_logic_for_indirect_property {
                 my $second_via_property_meta = $to_property_meta->via_property_meta;
                 my $final_class_name = $second_via_property_meta->data_type;
                 if ($final_class_name and $final_class_name ne 'UR::Value' and $final_class_name->isa('UR::Object')) {
-                    my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join;
-                    $bridge_linking_values = [ map { $_->[0] } @via2_join_properties ];
-                    $result_filtering_property = $via2_join_properties[0]->[1];
-                    $result_class_resolver = sub { $final_class_name };
+                    if ( 1 == (my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join)) {
+                        $bridge_linking_values = [ $via2_join_properties[0]->[0] ];
+                        $result_filtering_property = $via2_join_properties[0]->[1];
+                        $result_class_resolver = sub { $final_class_name };
 
-                    $final_result_property_name = $to_property_meta->to;
+                        $final_result_property_name = $to_property_meta->to;
+                    }
                 }
 
             } elsif ($to_property_meta->id_by) {

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -419,14 +419,14 @@ sub _resolve_bridge_logic_for_indirect_property {
 
         if ($to_property_meta->is_delegated and ! $to_property_meta->reverse_as) {
 
-            my($result_class_resolver, $bridge_linking_values, $final_result_property_name, $result_filtering_property);
+            my($result_class_resolver, $bridge_linking_properties, $final_result_property_name, $result_filtering_property);
             if ($to_property_meta->via) {
                 # bridges through another via-to property
                 my $second_via_property_meta = $to_property_meta->via_property_meta;
                 my $final_class_name = $second_via_property_meta->data_type;
                 if ($final_class_name and $final_class_name ne 'UR::Value' and $final_class_name->isa('UR::Object')) {
                     if ( 1 == (my @via2_join_properties = $second_via_property_meta->get_property_name_pairs_for_join)) {
-                        $bridge_linking_values = [ $via2_join_properties[0]->[0] ];
+                        $bridge_linking_properties = [ $via2_join_properties[0]->[0] ];
                         $result_filtering_property = $via2_join_properties[0]->[1];
                         $result_class_resolver = sub { $final_class_name };
 
@@ -435,7 +435,7 @@ sub _resolve_bridge_logic_for_indirect_property {
                 }
 
             } elsif ($to_property_meta->id_by) {
-                $bridge_linking_values = $to_property_meta->id_by;
+                $bridge_linking_properties = $to_property_meta->id_by;
                 $result_filtering_property = 'id';
                 if ($to_property_meta->id_class_by) {
                     # Bridging through an 'id_class_by' property
@@ -456,7 +456,7 @@ sub _resolve_bridge_logic_for_indirect_property {
 
                 sub {
                     my $bridge = shift;
-                    my @id = map { $bridge->$_ } @$bridge_linking_values;
+                    my @id = map { $bridge->$_ } @$bridge_linking_properties;
 
                     my $result_class = $result_class_resolver->($bridge);
                     my $id_resolver = $composite_id_resolver_for_class{ $result_class }

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -507,19 +507,10 @@ sub _resolve_bridge_crosser_for_doubly_delegated_property {
 
             my @results;
             foreach my $result_class ( keys %result_class_names_and_ids ) {
-                if (@_) {
-                    if($result_class->isa('UR::Value')) { #can't group queries together for UR::Values
-                        push @results, map { $result_class->get($result_filtering_property => $_, @_) } @{$result_class_names_and_ids{$result_class}};
-                    } else {
-                        push @results, $result_class->get($result_filtering_property => $result_class_names_and_ids{$result_class}, @_);
-                    }
-                }
-                else {
-                    if($result_class->isa('UR::Value')) { #can't group queries together for UR::Values
-                        push @results, map { $result_class->get($result_filtering_property => $_) } @{$result_class_names_and_ids{$result_class}};
-                    } else {
-                        push @results, $result_class->get($result_filtering_property => $result_class_names_and_ids{$result_class});
-                    }
+                if($result_class->isa('UR::Value')) { #can't group queries together for UR::Values
+                    push @results, map { $result_class->get($result_filtering_property => $_, @_) } @{$result_class_names_and_ids{$result_class}};
+                } else {
+                    push @results, $result_class->get($result_filtering_property => $result_class_names_and_ids{$result_class}, @_);
                 }
             }
 

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -417,7 +417,7 @@ sub _resolve_bridge_logic_for_indirect_property {
             };
         };
 
-        if ($to_property_meta->is_delegated) {
+        if ($to_property_meta->is_delegated and ! $to_property_meta->reverse_as) {
 
             my($result_class_resolver, $bridge_linking_values, $final_result_property_name, $result_filtering_property);
             if ($to_property_meta->via) {

--- a/lib/UR/Object/Type/AccessorWriter.pm
+++ b/lib/UR/Object/Type/AccessorWriter.pm
@@ -418,6 +418,12 @@ sub _resolve_bridge_logic_for_indirect_property {
         };
 
         if ($to_property_meta->is_delegated) {
+            # This property's value is doubly delegated.  The simple thing to
+            # do is to collect the bridge objects, then call the second
+            # delegation method on each bridge in a loop to collect the final
+            # results, which may trigger one query per result.  Depending on
+            # the type of delegation, the final results can be collected with
+            # one query
 
             my($result_class_resolver, $bridge_linking_properties, $final_result_property_name, $result_filtering_property);
             if ($to_property_meta->via) {

--- a/t/URT/t/87_is_many_indirect_is_efficient.t
+++ b/t/URT/t/87_is_many_indirect_is_efficient.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=> 13;
+use Test::More tests=> 14;
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
@@ -143,3 +143,12 @@ $query_count = 0;
 my @prices = $person->car_parts_prices();
 is(scalar(@prices), 4, "person's cars have 4 car_parts with prices");
 is($query_count, 1, 'Made 1 query');
+
+URT::CarParts->unload();
+$query_count = 0;
+my @parts = $person->car_parts;
+my @parts_ids = sort { $a <=> $b }
+                map { $_->id } @parts;
+is_deeply(\@parts_ids,
+          [1, 2, 9, 10],
+          'Got the correct CarParts objects');

--- a/t/URT/t/87_is_many_indirect_is_efficient.t
+++ b/t/URT/t/87_is_many_indirect_is_efficient.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=> 14;
+use Test::More tests=> 15;
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
@@ -147,6 +147,7 @@ is($query_count, 1, 'Made 1 query');
 URT::CarParts->unload();
 $query_count = 0;
 my @parts = $person->car_parts;
+is($query_count, 1, 'Made 1 query getting car_parts for person');
 my @parts_ids = sort { $a <=> $b }
                 map { $_->id } @parts;
 is_deeply(\@parts_ids,

--- a/t/URT/t/87g_doubly_delegated_multiple_pk_works.t
+++ b/t/URT/t/87g_doubly_delegated_multiple_pk_works.t
@@ -1,0 +1,115 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use File::Basename;
+use lib File::Basename::dirname(__FILE__)."/../../../lib";
+use lib File::Basename::dirname(__FILE__).'/../..';
+
+# Tests that the code to efficiently load data from double delegated properties
+# works properly when the linkage between classes involves multiple primary keys
+
+# This is essentially the same test as 87_is_many_indirect_is_efficient.t, except
+# that the link between Car and CarPart has a 2-column foreign key.  This means
+# the system needs to perform more than one query to collect the result objects
+
+use URT;
+
+subtest 'via/reverse-as' => sub {
+    plan tests => 7;
+
+    ok(UR::Object::Type->define(
+        class_name => 'URT::Person',
+        id_by => [
+            person_id => { is => 'NUMBER' },
+        ],
+        has => [
+            name      => { is => 'String' },
+            is_cool   => { is => 'Boolean' },
+            cars       => { is => 'URT::Car', reverse_as => 'owner', is_many => 1, is_optional => 1 },
+            primary_car => { is => 'URT::Car', via => 'cars', to => '__self__', where => ['is_primary true' => 1] },
+            primary_car_parts => { via => 'primary_car', to => 'parts' },
+            car_color => { via => 'cars', to => 'color' },
+
+            car_parts => { is => 'URT::CarParts', via => 'cars', to => 'parts', is_optional => 1, is_many => 1 },
+            car_parts_prices => { via => 'cars', to => 'parts_prices', is_optional => 1, is_many => 1 },
+        ],
+    ),
+    'Created class for people');
+
+    ok(UR::Object::Type->define(
+            class_name => 'URT::Car',
+            id_by => [
+                car_id  =>           { is => 'NUMBER' },
+                car_id2 =>           { is => 'NUMBER' },
+            ],
+            has => [
+                color   => { is => 'String' },
+                is_primary => { is => 'Boolean' },
+                owner   => { is => 'URT::Person', id_by => 'owner_id' },
+                parts   => { is => 'URT::CarParts', reverse_as => 'car', is_many => 1 },
+                parts_prices => { via => 'parts', to => 'price', is_many => 1},
+            ],
+        ),
+        "Created class for Car");
+
+    ok(UR::Object::Type->define(
+            class_name => 'URT::CarParts',
+            id_by => 'part_id',
+            has => [
+                name => { is => 'String' },
+                price => { is => 'Integer' },
+                car   => { is => 'URT::Car', id_by => ['car_id', 'car_id2'] },
+            ],
+        ),
+        "Created class for CarParts");
+            
+    # Create some objects
+    # Bob and Mike have red cars, Fred and Joe have blue cars.  Frank has no car.  Bob, Joe and Frank are cool
+    # Bob also has a yellow car that's his primary car
+    foreach my $row ( [ 1, 'Bob',1 ], [2, 'Fred',0], [3, 'Mike',0],[4,'Joe',1], [5,'Frank', 1] ) {
+        my %args; @args{qw( person_id name is_cool )} = @$row;
+        URT::Person->create(%args);
+    }
+
+    foreach my $row ( [ 1,1,'red',0,1], [ 2,2,'blue',1, 2], [3,3,'red',1,3],[4,4,'blue',1,4],[5,5,'yellow',1,1] ) {
+        my %args; @args{qw( car_id car_id2 color is_primary owner_id )} = @$row;
+        URT::Car->create(%args);
+    }
+
+    # Bob's non-primary car has wheels and engine,
+    # Bob's primary car has custom wheels and neon lights
+    # Fred's car has wheels and seats
+    # Mike's car has engine and radio
+    # Joe's car has seats and radio
+    foreach my $row ( [1, 'wheels', 100, 1,1],
+                      [2, 'engine', 200, 1,1],
+                      [3, 'wheels', 100, 2,2],
+                      [4, 'seats',  50,  2,2],
+                      [5, 'engine', 200, 3,3],
+                      [6, 'radio',  50,  3,3],
+                      [7, 'seats',  50,  4,4],
+                      [8, 'radio',  50,  4,4],
+                      [9, 'custom wheels', 200, 5,5],
+                      [10,'neon lights',   100, 5,5],
+                    ) {
+        my %args; @args{qw( part_id name price car_id car_id2 )} = @$row;
+        URT::CarParts->create(%args);
+    }
+
+    my $person = URT::Person->get(1);
+    ok($person, 'Got person object');
+
+    my @colors = $person->cars();
+    is(scalar(@colors), 2, 'person has 2 cars with colors');
+
+    my @prices = $person->car_parts_prices();
+    is(scalar(@prices), 4, "person's cars have 4 car_parts with prices");
+
+    URT::CarParts->unload();
+    my @parts = $person->car_parts;
+    my @parts_ids = sort { $a <=> $b }
+                    map { $_->id } @parts;
+    is_deeply(\@parts_ids,
+              [1, 2, 9, 10],
+              'Got the correct CarParts objects');
+};


### PR DESCRIPTION
This branch refactors the special query-efficiency code used to speed up doubly delegated properties.  It combines the common code for the 3 cases that were already handled (via/via, via/id-by, via/id-class-by) and extracts the special handler code to its own function.

The branch also adds support for efficiently querying the remaining case (via/reverse-as) and adds tests to cover the cases the efficiency code balks on (multiple foreign key properties)