### PR TITLE
Regular expression that matches more quickly on large Data::Dumper dumps.

### DIFF
--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -2805,7 +2805,7 @@ sub display_invalid_data_for_save {
         my $datadumper = Data::Dumper::Dumper($obj);
         my $nr_of_lines = $datadumper =~ tr/\n//;
         if ($nr_of_lines > 40) {
-            # trim it down to the first and last 15 lines
+            # trim it down to the first 15 and last 3 lines
             $datadumper =~ m/^((?:.*\n){15})/;
             $msg .= $1;
             $datadumper =~ m/((?:.*(?:\n|$)){3})$/;

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -2808,7 +2808,7 @@ sub display_invalid_data_for_save {
             # trim it down to the first and last 15 lines
             $datadumper =~ m/^((?:.*\n){15})/;
             $msg .= $1;
-            $datadumper =~ m/((?:.*\n?){3})$/;
+            $datadumper =~ m/((?:.*(?:\n|$)){3})$/;
             $msg .= "[...]\n$1\n";
         } else {
             $msg .= $datadumper;


### PR DESCRIPTION
Our "Model Summary" command has been failing for awhile trying to reprocess invalid workflows.  It ends up taking a very long time to complete, because this regular expression is very slow to match over the dump of an `Workflow::Model` object.  This tweak makes it run much more quickly.