### PR TITLE
Observe once

### DIFF
--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -398,13 +398,9 @@ sub send_notification_to_observers {
     };
     
     foreach my $callback_info (@matches) {
-        my ($callback, $note) = @$callback_info;
+        my ($callback, $note, undef, $id, $once) = @$callback_info;
+        UR::Observer->get($id)->delete() if $once;
         $callback->($subject, $property, @data);
-    }
-
-    # delete once observers
-    foreach ( grep { $_->[4] } @matches ) {
-        UR::Observer->get($_->[3])->delete();
     }
 
     $sig_depth--;

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -401,6 +401,12 @@ sub send_notification_to_observers {
         my ($callback, $note) = @$callback_info;
         $callback->($subject, $property, @data);
     }
+
+    # delete once observers
+    foreach ( grep { $_->[4] } @matches ) {
+        UR::Observer->get($_->[3])->delete();
+    }
+
     $sig_depth--;
 
     return scalar(@matches);

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -393,6 +393,7 @@ sub send_notification_to_observers {
     $sig_depth++;
     if (@matches > 1) {
         no warnings;
+        # sort by priority
         @matches = sort { $a->[2] <=> $b->[2] } @matches;
     };
     

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -1213,6 +1213,8 @@ Adds an observer to an object, monitoring one or more of its properties for chan
 
 The specified callback is fired upon property changes which match the observation request.
 
+See L<UR::Observer> for details.
+
 =item create_mock
 
  $mock = SomeClass->create_mock(

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -18,6 +18,7 @@ UR::Object::Type->define(
         aspect          => { is => 'String', is_optional => 1 },
         priority        => { is => 'Number', is_optional => 1, default_value => 1 },
         note            => { is => 'String', is_optional => 1 },
+        once            => { is => 'Boolean', is_optional => 1, default_value => 0 },
     ],
     is_transactional => 1,
 );
@@ -92,7 +93,7 @@ sub _create_or_define {
     my ($subscription, $delete_subscription);
 
     $self->_insert_record_into_all_change_subscriptions($subject_class_name, $aspect, $subject_id,
-                                                        [$callback, $self->note, $self->priority, $self->id]);
+                                                        [$callback, $self->note, $self->priority, $self->id, $self->once]);
 
     return $self;
 }
@@ -325,6 +326,12 @@ passed four parameters: $self, $aspect, $old_value, $new_value.  In this case,
 $self is the object that is changing, not the UR::Observer instance (unless,
 of course, you have created an observer on UR::Observer).  The return value of
 the callback is ignored.
+
+=item once
+
+If the 'once' attribute is true, the observer is deleted immediately after
+the callback is run.  This has the effect of running the callback only once,
+no matter how many times the observer condition is triggered.
 
 =item note
 


### PR DESCRIPTION
This adds a 'once' attribute to Observers.  Their callbacks will only run once, then the observer will be deleted.  It's deleted before the callback runs, so we won't have to worry about recursive calls, such as when calling commit() in a commit observer.