### PR TITLE
add missing dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -36,9 +36,10 @@ requires 'Module::Runtime', 'v0.014';
 
 on test => sub {
     requires 'Test::More', '0.98';
-    requires 'Test::Fork';
-    requires 'Test::Exception';
     requires 'Test::Deep';
+    requires 'Test::Exception';
+    requires 'Test::Fatal';
+    requires 'Test::Fork';
 };
 
 on develop => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -38,6 +38,7 @@ on test => sub {
     requires 'Test::More', '0.98';
     requires 'Test::Fork';
     requires 'Test::Exception';
+    requires 'Test::Deep';
 };
 
 on develop => sub {


### PR DESCRIPTION
I discovered Test::Deep is a dependency but it wasn't caught because Travis CI
must already install it.