### PR TITLE
Bugfix when List::MoreUtils::PP is used

### DIFF
--- a/lib/UR/Object/Set.pm
+++ b/lib/UR/Object/Set.pm
@@ -148,8 +148,10 @@ sub member_iterator {
 sub _members_have_changes {
     my $self = shift;
     return 1 if $self->{__members_have_changes};
+
+    my @property_names = @_;
     my $rule = $self->rule;
-    return any { $rule->evaluate($_) && $_->__changes__(@_) } $self->member_class_name->is_loaded;
+    return any { $rule->evaluate($_) && $_->__changes__(@property_names) } $self->member_class_name->is_loaded;
 }
 
 sub subset {


### PR DESCRIPTION
91b_sets_count_with_changes.t was failing only in TravisCI, and only in Perl
5.8.  For some unknown reason, that one version of Perl uses the pure-perl
module while all the others use the XS module.  This test reliably fails when
the env var LIST_MOREUTILS_PP=1

When the pure-perl version of any() is used, it inserts a function call
frame to evaluate the block that isn't there when the XS version is used.
This extra frame sets @_ to the empty list which causes __changes__ to check
all properties on the object, not just the ones the caller is interested in.

The XS version probably uses a shortcut to call the block that doesn't set up
a proper function call with its own @_.