### PR TITLE
Added XML::Dumper and XML::LibXSLT as prerequisites in META.json

### DIFF
--- a/META.json
+++ b/META.json
@@ -78,6 +78,8 @@
             "Template" : "0",
             "Text::Diff" : "0.35",
             "Text::Glob" : "0",
+            "XML::Dumper" : "0",
+            "XML::LibXSLT" : "0",
             "YAML" : "0",
             "perl" : "v5.8.7",
             "version" : "0"


### PR DESCRIPTION
It seems these two missing XML modules in the prerequisites are causing fails on cpantesters.org:

http://www.cpantesters.org/cpan/report/d00181b0-076e-11e4-84c4-fc77f9652e90
http://www.cpantesters.org/cpan/report/9fe36504-03ca-11e4-84c4-fc77f9652e90