### PR TITLE
Fix bug in object cache pruner

### DIFF
--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -1450,6 +1450,7 @@ sub prune_object_cache {
 
             foreach my $id ( keys ( %$objects_for_class ) ) {
                 my $obj = $objects_for_class->{$id};
+                next unless defined $obj;  # object with this ID does not exist
                 if (
                     $obj->is_weakened
                     || $obj->is_prunable && $obj->{__get_serial} && $obj->{__get_serial} <= $target_serial

--- a/t/URT/t/52_limit_cache_size.t
+++ b/t/URT/t/52_limit_cache_size.t
@@ -6,7 +6,7 @@ use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__)."/../..";
 use URT;
 
-use Test::More tests => 23;
+use Test::More tests => 25;
 use URT::DataSource::SomeSQLite;
 
 &setup_classes_and_db();
@@ -22,6 +22,11 @@ my $thing = URT::Thing->get(thing_id => 1);
 ok($thing, 'Got thing_id 1');
 
 is( &count_things_in_cache(), 1, 'There is one object in the cache');
+
+# Ask for an object that doesn't exist
+my $not_thing = URT::Thing->get(thing_id => 99999);
+ok(! $not_thing, 'get() for object that does not exist');
+is( &count_things_in_cache(), 1, 'Still one object in the cache');
 
 # We'll hold on to these, too
 my @keep_datas = $thing->datas();
@@ -156,7 +161,7 @@ sub count_things_in_cache {
 #        foreach (values %{$UR::Context::all_objects_loaded->{$c}} ) {
 #            print "\tid ",$_->id,"\n";
 #        }
-        $count += scalar(values %{$UR::Context::all_objects_loaded->{$c}});
+        $count += scalar(grep { defined } values %{$UR::Context::all_objects_loaded->{$c}});
     }
     return $count;
 }


### PR DESCRIPTION
If a slot in the object cache has the value 'undef', that means a request
was made to the DB for that object, but it doesn't exist.  The pruner needs
to skip over those undef values.