### PR TITLE
Three possible APIs for configurable roles

### DIFF
--- a/deferred.pl
+++ b/deferred.pl
@@ -1,0 +1,50 @@
+# Using UR::Role exports a function deferred() which returns a dummy
+# placeholder object.
+#
+# When the role is consumed, classes would be allowed to redefine a property
+# declared in a role but would have to declare that it's either an override
+# (completely replaces the role's property) or augments it (only the property
+# keys mentioned in the class's definition override the keys in the role's
+# definition), otherwise an exception is thrown.
+#
+# After role's properties are mixed in to the class, if any placeholders still
+# exist, an exception is thrown, which forces the consuming class to provide
+# values for all the deferred values.
+
+package My::Role;
+
+use UR::Role;  # exports deferred() function
+role My::Role {
+    has => [
+        role_param => { is => deferred, doc => 'blah blah blah' },
+    ],
+};
+
+package My::Class;
+
+class My::Class {
+    roles => 'My::Role',
+    has => [
+        role_param => { is => 'Some::Data::Type', augments => 'My::Role' },
+    ],
+};
+
+package Your::Class;
+
+class Your::Class {
+    roles => 'My::Role',
+    has => [
+        role_param => { is => 'Other::Data::Type', augments => 'My::Role' },
+    ],
+}
+
+package main;
+
+my $my_param_value = Some::Data::Type->create();
+my $my_obj = My::Class->create(role_param => $my_param_value);
+
+my $your_param_value = Other::Data::Type->create();
+my $your_obj = Your::Class->create(role_param => $your_param_value);
+
+
+

--- a/role_prop_function.pl
+++ b/role_prop_function.pl
@@ -1,0 +1,57 @@
+# Parameterised roles where the parameters are implemented as a function
+# that returns an object with methods corresponding to the parameters of
+# the composed role.
+#
+# Declaring a role creates a Role Prototype (similar to how declaring a class
+# creates a Class meta-object).  A role creates a constructor function with
+# the same name as the role's package that return a Role Instance.  This Role
+# Instance represents a Role Prototype being consumed to one particular Class
+# with a set of parameters.
+#
+# Before the role is consumed, the value returned by the method call is a
+# placeholder object that knows what method was called of it.
+#
+# When the role is composed into a class, the role's parameters are bound to
+# one particular instance of the role.  The role definition is scanned for
+# placeholder objects and replaced with the actual parameter values.  The
+# role_prop() function in the role's namespace is replaced by a function
+# that can search the call stack for the closest function call with an
+# invocant that consumed the role, and returns the proper value for the
+# requested attribute.
+
+package My::Role;
+
+use UR::Role;  # exports role_prop() function
+
+role My::Role {
+    has => [
+        role_param => { is => role_prop->data_type, doc => 'blah blah blah' },
+    ],
+};
+
+sub print_role_param_type {
+    print "role_param type is " . role_prop->data_type . "\n";
+}
+
+package My::Class;
+
+class My::Class {
+    roles => My::Role(data_type => 'Some::Data::Type'),
+};
+
+package Your::Class;
+
+class Your::Class {
+    roles => My::Role(data_type => 'Other::Data::Type'),
+}
+
+package main;
+
+my $my_param_value = Some::Data::Type->create();
+my $my_obj = My::Class->Create(role_param => $my_param_value);
+$my_obj->print_role_param_type(); # prints "role_param type is Some::Data::Type"
+
+my $your_param_value = Other::Data::Type->create();
+my $your_obj = Your::Class->create(role_param => $your_param_value);
+$your_obj->print_role_param_type(); # prints "role_param type is Other::Data::Type"
+

--- a/role_variables.pl
+++ b/role_variables.pl
@@ -1,0 +1,61 @@
+# Parameterized roles where the parameters are implemented as variables within
+# the role's package.  These variables are annotated with the RoleProperty
+# attribute which registers them with the role composition machinery with the
+# given name.
+#
+# Declaring a role creates a Role Prototype (similar to how declaring a class
+# creates a Class meta-object).  A role creates a constructor function with
+# the same name as the role's package that return a Role Instance.  This Role
+# Instance represents a Role Prototype being consumed to one particular Class
+# with a set of parameters.
+#
+# Before the role is consumed, the value of the variable is a placeholder
+# object.
+#
+# When the role is composed into a class, the role's parameters are bound to
+# one particular instance of the role.  The role definition is scanned for
+# placeholder objects and replaced with the actual parameter values.  The
+# variable's value is replaced by a tied object with "magic" functionality to
+# determine which role instance by searching the call stack for the closest
+# function call with an invocant that consumed the role and returning its
+# parameter value.
+
+package My::Role;
+
+use UR::Role;
+# Having to repeat the name in the attribute can be eliminated by using the
+# PadWalker module
+my $data_type : RoleProperty(data_type);
+
+role My::Role {
+    has => [
+        role_param => { is => $data_type, doc => 'blah blah blah' },
+    ],
+};
+
+sub print_role_param_type {
+    print "role_param type is $data_type\n";
+}
+
+package My::Class;
+
+class My::Class {
+    roles => My::Role(data_type => 'Some::Data::Type'),
+};
+
+package Your::Class;
+
+class Your::Class {
+    roles => My::Role(data_type => 'Other::Data::Type'),
+}
+
+package main;
+
+my $my_param_value = Some::Data::Type->create();
+my $my_obj = My::Class->create(role_param => $my_param_value);
+$my_obj->print_role_param_type(); # prints "role_param type is Some::Data::Type"
+
+my $your_param_value = Other::Data::Type->create();
+my $your_obj = Your::Class->create(role_param => $your_param_value);
+$your_obj->print_role_param_type(); # prints "role_param type is Other::Data::Type"
+


### PR DESCRIPTION
This branch is for discussion on three possible implementations for allowing roles which leave some of their configuration to the classes which consume them.  The reason for wanting this is to allow Genome::Notable::Command::AddNote and ::ViewNotes to be turned into roles.  Specifically, their ```notable``` property needs to have a configurable ```is``` depending on whether they're consumed by Genome::Model::Command::AddNote or Genome::Model::Build::Command::AddNote.

Here are three possible APIs.  Each example is in a file to itself.  They all define one role and two classes that consume that role.  The last two are inspired by [Perl6 parameterized roles](http://doc.perl6.org/language/objects#Parameterized_Roles) and allow the configurable items to be used in more than just role definitions.

I have prototype code working (to some degree) for all three.

```deferred.pl``` uses a function ```deferred()``` to indicate that part of a role's definition is deferred to the consuming class.  The classes must provide values for all of theses deferred values.

```role_prop.pl``` also uses a function ```role_prop()``` to allow access to configurable role parameters specified when the role is consumed by a class.  UR::Role would export this function.  Before the role is consumed (ie. during the role definition), this function returns placeholder objects that remember what param value they represent.  When the role is consumed by a class, these placeholders are replaced by the actual values supplied, and the ```role_prop()``` function is replaced by a new function that can figure out which class is being used as the invocant, and supply the proper value depending on which class the invocant belongs to.  It does this by looking up the call stack for each function's first argument (the invocant), and matching it up with which classes have consumed that role.

```role_variables.pl``` is essentially the same mechanism as ```role_prop.pl```, except that it uses variables with the RoleProperty attribute.  The same swapout behavior is used here: before composition, the variable's value is a placeholder, after composition its value is a tied scalar that does the same magic call stack lookup.

Maybe something else entirely?

One thing that stands out is that the role constructor functions in the last two actually pollute the parent package: Role ```My::Cool::Role``` would create a function ```Role()``` in the ```My::Cool``` package.  I think it reads nice, but maybe forcing the developer to use a construct like ```My::Cool::Role->create()``` would be better.