### PR TITLE
required changes to fix observer issues in Genome

### DIFF
--- a/lib/Command/Common.pm
+++ b/lib/Command/Common.pm
@@ -8,6 +8,7 @@ use UR;
 # Once roles exist this should probably be a role.
 class Command::Common {
     is_abstract => 1,
+    valid_signals => [qw(error_die)],
 };
 
 sub create {

--- a/lib/Command/V1.pm
+++ b/lib/Command/V1.pm
@@ -40,22 +40,6 @@ eval {
     binmode STDERR, ":utf8";
 };
 
-# Override method in UR::Object to support error_die and error_rv_false
-sub validate_subscription {
-    my $self = shift;
-    my $subscription_property = shift;
-
-    my $retval = $self->SUPER::validate_subscription($subscription_property, @_);
-    return $retval if $retval;
-
-    unless ( defined($subscription_property) and $subscription_property eq 'error_die') {
-        $subscription_property = '(undef)' unless defined ($subscription_property);
-        Carp::croak("Unrecognized subscription aspect '$subscription_property'");
-    }
-
-    return 1;
-}
-
 sub _init_subclass {
     # Each Command subclass has an automatic wrapper around execute().
     # This ensures it can be called as a class or instance method,

--- a/lib/UR/BoolExpr.pm
+++ b/lib/UR/BoolExpr.pm
@@ -615,8 +615,10 @@ sub resolve {
                     $is_many = $property_meta->is_many;
                 }
                 else {
-                    $data_type = $subject_class_meta->{has}{$property_name}{data_type};
-                    $is_many = $subject_class_meta->{has}{$property_name}{is_many};
+                    if (exists $subject_class_meta->{has}{$property_name}) {
+                        $data_type = $subject_class_meta->{has}{$property_name}{data_type};
+                        $is_many = $subject_class_meta->{has}{$property_name}{is_many};
+                    }
                 }
                 $data_type ||= '';
 

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -22,6 +22,7 @@ UR::Object::Type->define(
                                       default_value => undef,
                                       doc => 'Flag indicating whether the context must (1), must not (0) or may (undef) query underlying contexts when handling a query'  },
     ],
+    valid_signals => [qw(precommit sync_databases commit prerollback rollback)],
     doc => <<EOS
 The environment in which all data examination and change occurs in UR.  The current context represents the current 
 state of everything, and acts as a manager/intermediary between the current application and underlying database(s).

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -1569,9 +1569,6 @@ sub value_for_object_property_in_underlying_context {
         Carp::croak(qq(No object found in underlying context));
     }
 
-    unless (exists $saved->{$property_name}) {
-        Carp::croak(qq(No value for property '$property_name' in underlying context));
-    }
     return $saved->{$property_name};
 }
 

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -1561,6 +1561,21 @@ sub _object_cache_pruning_report {
 }
 
 
+sub value_for_object_property_in_underlying_context {
+    my ($self, $obj, $property_name) = @_;
+
+    my $saved = $obj->{db_saved_uncommitted} || $obj->{db_committed};
+    unless ($saved) {
+        Carp::croak(qq(No object found in underlying context));
+    }
+
+    unless (exists $saved->{$property_name}) {
+        Carp::croak(qq(No value for property '$property_name' in underlying context));
+    }
+    return $saved->{$property_name};
+}
+
+
 # True if the object was loaded from an underlying context and/or datasource, or if the
 # object has been committed to the underlying context
 sub object_exists_in_underlying_context {

--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -272,10 +272,7 @@ sub changes_can_be_saved {
     # TODO: limit to objects that changed within transaction as to not duplicate
     # error checking unnecessarily.
 
-    my @changed_objects = (
-        $self->all_objects_loaded('UR::Object::Ghost'),
-        grep { $_->__changes__ } $self->all_objects_loaded('UR::Object')
-    );
+    my @changed_objects = map { $_->changed_class_name->get($_->changed_id) } $self->get_changes();
 
     # This is primarily to catch custom validity logic in class overrides.
     my @invalid = grep { $_->__errors__ } @changed_objects;

--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -180,37 +180,39 @@ sub rollback {
         die "Parent transaction $parent is not below this one on the stack $open_transaction_stack[-2]?";
     }
 
-    # Reverse each change, starting from the most recent, and
-    # ending with the creation of the transaction object itself.
-    local $log_all_changes = 0;
+    {
+        # Reverse each change, starting from the most recent, and
+        # ending with the creation of the transaction object itself.
+        local $log_all_changes = 0;
 
 
-    $self->__signal_change__('rollback', 1);
-    my @changes_to_undo = reverse $self->get_changes();
-    my $transaction_change = pop @changes_to_undo;
-    my $transaction = $transaction_change->changed_class_name->get($transaction_change->changed_id);
-    unless ($self == $transaction && $transaction_change->changed_aspect eq 'create') {
-        die "First change was not the creation of this transaction!";
-    }
-    for my $change (@changes_to_undo) {
-        if ($change == $changes_to_undo[0]) {
-            # the transaction reverses itself in its own context,
-            # but the removal of the transaction itself happens in the parent context
-            $UR::Context::current = $parent;
+        $self->__signal_change__('rollback', 1);
+        my @changes_to_undo = reverse $self->get_changes();
+        my $transaction_change = pop @changes_to_undo;
+        my $transaction = $transaction_change->changed_class_name->get($transaction_change->changed_id);
+        unless ($self == $transaction && $transaction_change->changed_aspect eq 'create') {
+            die "First change was not the creation of this transaction!";
+        }
+        for my $change (@changes_to_undo) {
+            if ($change == $changes_to_undo[0]) {
+                # the transaction reverses itself in its own context,
+                # but the removal of the transaction itself happens in the parent context
+                $UR::Context::current = $parent;
+            }
+
+            $change->undo;
+            $change->delete;
         }
 
-        $change->undo;
-        $change->delete;
-    }
-
-    for my $change (@changes_to_undo) {
-        unless($change->isa('UR::DeletedRef')) {
-            Carp::confess("Failed to undo a change during transaction rollback.");
+        for my $change (@changes_to_undo) {
+            unless($change->isa('UR::DeletedRef')) {
+                Carp::confess("Failed to undo a change during transaction rollback.");
+            }
         }
-    }
 
-    $transaction_change->undo;
-    $transaction_change->delete;
+        $transaction_change->undo;
+        $transaction_change->delete;
+    }
 
     $#change_log = $begin_point-1;
 
@@ -220,6 +222,9 @@ sub rollback {
     }
 
     pop @open_transaction_stack;
+    unless (@open_transaction_stack) {
+        $log_all_changes = 0;
+    }
     $UR::Context::current = $parent;
 
     return 1;
@@ -258,6 +263,9 @@ sub commit {
         $self->__signal_change__('commit',0);
     }
     pop @open_transaction_stack;
+    unless (@open_transaction_stack) {
+        $log_all_changes = 0;
+    }
 
     $UR::Context::current = $self->parent;
     return 1;

--- a/lib/UR/DataSource/RDBMS.pm
+++ b/lib/UR/DataSource/RDBMS.pm
@@ -3485,29 +3485,6 @@ sub _generate_class_data_for_loading {
 
     return $class_data;
 }
-        
-# We're overriding the method in UR::Object because we support 2 more
-# event types: connect and query
-sub validate_subscription {
-    my $self = shift;
-    my $subscription_property = shift;
-
-    my $retval = $self->SUPER::validate_subscription($subscription_property,@_);
-    return $retval if $retval;
-
-    unless ( defined($subscription_property)
-             and
-             ( #$subscription_property eq 'connect'
-               #or
-               $subscription_property eq 'query'
-             )
-    ) {
-        $subscription_property = '(undef)' unless defined ($subscription_property);
-        Carp::croak("Unrecognized subscription aspect '$subscription_property'");
-    }
-
-    return 1;
-}
 
 sub _select_clause_for_table_property_data {
     my $self = shift;

--- a/lib/UR/DataSource/RDBMSRetriableOperations.pm
+++ b/lib/UR/DataSource/RDBMSRetriableOperations.pm
@@ -29,7 +29,7 @@ sub _retriable_operation {
     my $self = UR::Util::object(shift);
     my $code = shift;
 
-    _make_retriable_operation_observer();
+    _make_retriable_operation_observer($self);
 
     RETRY_LOOP:
     for( my $db_retry_sec = $self->retry_sleep_start_sec;
@@ -56,17 +56,17 @@ sub _retriable_operation {
 
 
 {
-    my @retry_observers;
+    my %retry_observers;
     sub _make_retriable_operation_observer {
-        unless (@retry_observers) {
-            @retry_observers = map {
-                __PACKAGE__->add_observer(
+        my $self = shift;
+        unless ($retry_observers{$self->class}++) {
+            for (qw(query_failed commit_failed do_failed connect_failed sequence_nextval_failed)) {
+                $self->add_observer(
                     aspect => $_,
                     priority => 99999, # Super low priority to fire last
                     callback => \&_db_retry_observer,
                 );
             }
-            qw(query_failed commit_failed do_failed connect_failed sequence_nextval_failed);
         }
     }
 }

--- a/lib/UR/DataSource/RDBMSRetriableOperations.pm
+++ b/lib/UR/DataSource/RDBMSRetriableOperations.pm
@@ -29,7 +29,7 @@ sub _retriable_operation {
     my $self = UR::Util::object(shift);
     my $code = shift;
 
-    _make_retriable_operation_observer($self);
+    $self->_make_retriable_operation_observer();
 
     RETRY_LOOP:
     for( my $db_retry_sec = $self->retry_sleep_start_sec;

--- a/lib/UR/DeletedRef.pm
+++ b/lib/UR/DeletedRef.pm
@@ -61,6 +61,10 @@ sub AUTOLOAD {
     Carp::croak("Attempt to use a reference to an object which has been deleted.  A call was made to method '$method'\nRessurrect it first.\n" . Dumper($_[0]));
 }
 
+sub __rollback__ {
+    return 1;
+}
+
 sub DESTROY {
     if ($ENV{'UR_DEBUG_OBJECT_RELEASE'}) {
         print STDERR "MEM DESTROY deletedref $_[0]\n";

--- a/lib/UR/ModuleBase.pm
+++ b/lib/UR/ModuleBase.pm
@@ -759,6 +759,9 @@ $create_subs_for_message_type = sub {
         into => $class,
         as => $logger_subname,
     });
+
+    # "Register" the message type as a valid signal.
+    $UR::Object::Type::STANDARD_VALID_SIGNALS{$logger_subname} = 1;
 };
 
 sub _carp_sprintf {

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -338,9 +338,11 @@ sub add_observer {
     my $self = shift;
     my %params = @_;
 
+    if (ref($self)) {
+        $params{subject_id} = $self->id;
+    }
     my $observer = UR::Observer->create(
         subject_class_name => $self->class,
-        subject_id => (ref($self) ? $self->id : undef),
         %params,
     );
     unless ($observer) {

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -725,23 +725,14 @@ sub __rollback__ {
 }
 
 
-sub __saved_value_for_property__ {
-    my ($self, $property_name) = @_;
-    my $saved = $self->{db_saved_uncommitted} || $self->{db_committed};
-    unless ($saved) {
-        Carp::croak(qq(No saved value for property '$property_name'));
-    }
-    return $saved->{$property_name};
-}
-
-
 sub __rollback_property__ {
     my ($self, $property_name) = @_;
     my $saved = $self->{db_saved_uncommitted} || $self->{db_committed};
     unless ($saved) {
         Carp::croak(qq(Cannot rollback property '$property_name' because it has no saved state));
     }
-    return $self->$property_name($self->__saved_value_for_property__($property_name));
+    my $saved_value = UR::Context->current->value_for_object_property_in_underlying_context($self, $property_name);
+    return $self->$property_name($saved_value);
 }
 
 

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -707,7 +707,7 @@ sub __rollback__ {
             || $property_meta->is_constant
         );
     };
-    my @rollback_properties_names =
+    my @rollback_property_names =
         map { $_->property_name }
         grep { $should_rollback->($_) }
         map { $meta->property_meta_for_name($_) }
@@ -715,7 +715,7 @@ sub __rollback__ {
 
     # Existing object.  Undo all changes since last sync, or since load
     # occurred when there have been no syncs.
-    foreach my $property_name ( @rollback_properties_names ) {
+    foreach my $property_name ( @rollback_property_names ) {
         $self->__rollback_property__($property_name);
     }
 

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -716,11 +716,22 @@ sub __rollback__ {
     # Existing object.  Undo all changes since last sync, or since load
     # occurred when there have been no syncs.
     foreach my $property_name ( @rollback_properties_names ) {
-        $self->$property_name($saved->{$property_name});
+        $self->__rollback_property__($property_name);
     }
+
     delete $self->{'_change_count'};
 
     return $self;
+}
+
+
+sub __rollback_property__ {
+    my ($self, $property_name) = @_;
+    my $saved = $self->{db_saved_uncommitted} || $self->{db_committed};
+    unless ($saved) {
+        Carp::croak(qq(Cannot rollback property '$property_name' because it has no saved state));
+    }
+    return $self->$property_name($saved->{$property_name});
 }
 
 

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -725,13 +725,23 @@ sub __rollback__ {
 }
 
 
+sub __saved_value_for_property__ {
+    my ($self, $property_name) = @_;
+    my $saved = $self->{db_saved_uncommitted} || $self->{db_committed};
+    unless ($saved) {
+        Carp::croak(qq(No saved value for property '$property_name'));
+    }
+    return $saved->{$property_name};
+}
+
+
 sub __rollback_property__ {
     my ($self, $property_name) = @_;
     my $saved = $self->{db_saved_uncommitted} || $self->{db_committed};
     unless ($saved) {
         Carp::croak(qq(Cannot rollback property '$property_name' because it has no saved state));
     }
-    return $self->$property_name($saved->{$property_name});
+    return $self->$property_name($self->__saved_value_for_property__($property_name));
 }
 
 

--- a/lib/UR/Object/Ghost.pm
+++ b/lib/UR/Object/Ghost.pm
@@ -26,6 +26,34 @@ sub create { Carp::croak('Cannot create() ghosts.') };
 
 sub delete { Carp::croak('Cannot delete() ghosts.') };
 
+sub __rollback__ {
+    my $self = shift;
+
+    # revive ghost object
+
+    my $ghost_copy = eval("no strict; no warnings; " . Data::Dumper::Dumper($self));
+    if ($@) {
+        Carp::confess("Error re-constituting ghost object: $@");
+    }
+    my($saved_data, $saved_key);
+    if (exists $ghost_copy->{'db_saved_uncommitted'} ) {
+        $saved_data = $ghost_copy->{'db_saved_uncommitted'};
+    } elsif (exists $ghost_copy->{'db_committed'} ) {
+        $saved_data = $ghost_copy->{'db_committed'};
+    } else {
+        return; # This shouldn't happen?!
+    }
+
+    my $new_object = $self->live_class->UR::Object::create(%$saved_data);
+    $new_object->{db_committed} = $ghost_copy->{db_committed} if (exists $ghost_copy->{'db_committed'});
+    $new_object->{db_saved_uncommitted} = $ghost_copy->{db_saved_uncommitted} if (exists $ghost_copy->{'db_saved_uncommitted'});
+    unless ($new_object) {
+        Carp::confess("Failed to re-constitute $self!");
+    }
+
+    return $new_object;
+}
+
 sub _load {
     shift->is_loaded(@_);
 }

--- a/lib/UR/Object/Type/Initializer.pm
+++ b/lib/UR/Object/Type/Initializer.pm
@@ -345,9 +345,16 @@ sub initialize_bootstrap_classes
     # __define__ instead of create() so a subsequent rollback won't remove the observer
     # and since we're in bootstrapping time, we have to supply an ID.  The UUID generator
     # doesn't require any outside info, so it's safe to use
-    UR::Observer->__define__(id => UR::Object::Type->autogenerate_new_object_id_uuid,
-                             subject_class_name => 'UR::Object::Property',
-                             callback => \&UR::Object::Type::_property_change_callback);
+    UR::Observer->__define__(
+        id => UR::Object::Type->autogenerate_new_object_id_uuid,
+        subject_class_name => 'UR::Object::Property',
+        subject_id => '',
+        aspect => '',
+        priority => 1,
+        note => '',
+        once => 0,
+        callback => \&UR::Object::Type::_property_change_callback,
+    );
 }
 
 sub _normalize_class_description {

--- a/lib/UR/Object/Type/Initializer.pm
+++ b/lib/UR/Object/Type/Initializer.pm
@@ -341,12 +341,9 @@ sub initialize_bootstrap_classes
     }
     $bootstrapping = 0;
 
-    # It should be safe to set up callbacks now.
-    # __define__ instead of create() so a subsequent rollback won't remove the observer
-    # and since we're in bootstrapping time, we have to supply an ID.  The UUID generator
-    # doesn't require any outside info, so it's safe to use
-    UR::Observer->__define__(
-        id => UR::Object::Type->autogenerate_new_object_id_uuid,
+    # It should be safe to set up callbacks now.  register_callback() instead
+    # of create() so a subsequent rollback won't remove the observer.
+    UR::Observer->register_callback(
         subject_class_name => 'UR::Object::Property',
         subject_id => '',
         aspect => '',

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -1581,13 +1581,9 @@ sub __signal_change__ {
     return @rv;
 }
 
-our %STANDARD_VALID_SIGNALS = ( create        => 1,
-                                'delete'      => 1,
-                                commit        => 1,
-                                rollback      => 1,
-                                load          => 1,
-                                unload        => 1,
-                                load_external => 1 );
+my @default_valid_signals = qw(create delete commit rollback load unload load_external subclass_loaded);
+our %STANDARD_VALID_SIGNALS;
+@STANDARD_VALID_SIGNALS{@default_valid_signals} = (1) x @default_valid_signals;
 sub _is_valid_signal {
     my $self = shift;
     my $aspect = shift;

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -1475,7 +1475,8 @@ sub _property_change_callback {
         &_id_property_change_callback($property_obj, $change);
     }
 
-    if (exists $class_obj->{'has'}->{$property_name}->{$method}) {
+    if (exists $class_obj->{'has'}->{$property_name}
+        && exists $class_obj->{'has'}->{$property_name}->{$method}) {
         $class_obj->{'has'}->{$property_name}->{$method} = $new_val;
 
     } 

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -1593,7 +1593,7 @@ sub _is_valid_signal {
     my $aspect = shift;
 
     # An aspect of empty string (or undef) means all aspects are being observed.
-    return 1 unless (defined($aspect) or length($aspect));
+    return 1 unless (defined($aspect) and length($aspect));
 
     # All standard creation and destruction methods emit a signal.
     return 1 if ($STANDARD_VALID_SIGNALS{$aspect});

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -1591,8 +1591,8 @@ sub _is_valid_signal {
     my $self = shift;
     my $aspect = shift;
 
-    # Undefined attributes indicate that the subscriber wants any changes at all to generate a callback.
-    return 1 if (! defined $aspect);
+    # An aspect of empty string (or undef) means all aspects are being observed.
+    return 1 unless (defined($aspect) or length($aspect));
 
     # All standard creation and destruction methods emit a signal.
     return 1 if ($STANDARD_VALID_SIGNALS{$aspect});

--- a/lib/UR/ObjectDeprecated.pm
+++ b/lib/UR/ObjectDeprecated.pm
@@ -249,34 +249,14 @@ sub create_subscription  {
     return [@observer_params{'subject_class_name','subject_id','aspect','callback','note'}];
 }
 
+
 sub validate_subscription
 {
-    return 1;
-
-    my ($self,$subscription_property) = @_;
-
-    Carp::confess("The _create_object and _delete_object signals are no longer emitted!") 
-        if defined($subscription_property) 
-            and ($subscription_property eq '_create_object' or $subscription_property eq '_delete_object');
-
-    # Undefined attributes indicate that the subscriber wants any changes at all to generate a callback.
-    return 1 if (!defined($subscription_property));
-
-    # All standard creation and destruction methods emit a signal.
-    return 1 if ($subscription_property =~ /^(create|delete|commit|rollback|load|unload|load_external)$/);
-
-    # A defined attribute in our property list indicates the caller wants callbacks from our properties.
-    my $class_object = $self->__meta__;
-    for my $property ($class_object->all_property_names)
-    {
-        return 1 if $property eq $subscription_property;
-    }
-
-    return 1 if ($class_object->_is_valid_signal($subscription_property));
-
-    # Bad subscription request.
+    # Everything is invalid unless you make it valid by implenting
+    # validate_subscription on your class.  (Or use the new API.)
     return;
 }
+
 
 sub inform_subscription_cancellation
 {

--- a/lib/UR/ObjectDeprecated.pm
+++ b/lib/UR/ObjectDeprecated.pm
@@ -252,7 +252,7 @@ sub create_subscription  {
 
 sub validate_subscription
 {
-    # Everything is invalid unless you make it valid by implenting
+    # Everything is invalid unless you make it valid by implementing
     # validate_subscription on your class.  (Or use the new API.)
     return;
 }

--- a/lib/UR/ObjectDeprecated.pm
+++ b/lib/UR/ObjectDeprecated.pm
@@ -217,10 +217,20 @@ sub create_subscription  {
     # parse parameters
     my ($class,$id,$method,$callback,$note,$priority);
 
+    my %translate = (
+        method => 'aspect',
+        id => 'subject_id',
+    );
+    my @param_names = qw(method callback note priority id);
     my %observer_params;
-    @observer_params{'aspect','callback','note','priority','subject_id'} = delete @params{'method','callback','note','priority','id'};
+    for my $name (@param_names) {
+        if (exists $params{$name}) {
+            my $obs_name = $translate{$name} || $name;
+            $observer_params{$obs_name} = delete $params{$name};
+        }
+    }
+
     $observer_params{'subject_class_name'} = $self->class;
-    $observer_params{'priority'} = 1 unless defined $observer_params{'priority'};
     if (!defined $observer_params{'subject_id'} and ref($self)) {
         $observer_params{'subject_id'} = $self->id;
     }

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -221,6 +221,11 @@ sub delete {
     $self->SUPER::delete();
 }
 
+sub __rollback__ {
+    my $self = shift;
+    return UR::Observer::delete($self);
+}
+
 sub get_with_special_parameters {
     my($class,$rule,%extra) = @_;
 

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -72,6 +72,7 @@ sub _create_or_define {
 {
     my @has_defaults = qw(aspect note once priority subject_class_name subject_id);
     sub has_defaults { @has_defaults }
+
     my %defaults =
         map {
             $_ => __PACKAGE__->__meta__->{has}->{$_}->{default_value}
@@ -81,63 +82,63 @@ sub _create_or_define {
             && exists __PACKAGE__->__meta__->{has}->{$_}->{default_value}
         } @has_defaults;
     sub defaults_for_register_callback { %defaults }
-    sub register_callback {
-        my $class = shift;
-        my %params = @_;
-
-        unless (defined $params{id}) {
-            $params{id} = UR::Object::Type->autogenerate_new_object_id_uuid;
-        }
-
-        my %values = %defaults;
-        my @specified_params = grep { exists $params{$_} } @required_params_for_register;
-        @values{@specified_params} = map { delete $params{$_} } @specified_params;
-
-        my @bad_params = keys %params;
-        if (@bad_params) {
-            Carp::croak('invalid params: ' . join(', ', @bad_params));
-        }
-
-        my @missing_params = grep { not exists $values{$_} } @required_params_for_register;
-        if (@missing_params) {
-            Carp::croak('missing required params: ' . join(', ', @missing_params));
-        }
-
-        my @undef_values = grep { not defined $values{$_} } keys %values;
-        if (@undef_values) {
-            Carp::croak('undefined values: ' . join(', ', @undef_values));
-        }
-
-        my $subject_class_name = $values{subject_class_name};
-        my $subject_class_meta = eval { $subject_class_name->__meta__ };
-        if ($@) {
-            Carp::croak("Can't create observer with subject_class_name '$subject_class_name': Can't get class metadata for class '$subject_class_name': $@");
-        }
-        unless ($subject_class_meta) {
-            Carp::croak("Class $subject_class_name cannot be the subject class for an observer because there is no class metadata");
-        }
-
-        my $aspect = $values{aspect};
-        my $subject_id = $values{subject_id};
-        unless ($subject_class_meta->_is_valid_signal($aspect)) {
-            my $croak =  sub { Carp::croak("'$aspect' is not a valid aspect for class $subject_class_name") };
-            unless ($subject_class_name->can('validate_subscription')) {
-                $croak->();
-            }
-            unless ($subject_class_name->validate_subscription($aspect, $subject_id, $values{callback})) {
-                $croak->();
-            }
-        }
-
-        $class->_insert_record_into_all_change_subscriptions(
-            @values{qw(subject_class_name aspect subject_id)},
-            [@values{qw(callback note priority id once)}],
-        );
-
-        return $values{id};
-    }
 }
 
+sub register_callback {
+    my $class = shift;
+    my %params = @_;
+
+    unless (defined $params{id}) {
+        $params{id} = UR::Object::Type->autogenerate_new_object_id_uuid;
+    }
+
+    my %values = $class->defaults_for_register_callback();
+    my @specified_params = grep { exists $params{$_} } @required_params_for_register;
+    @values{@specified_params} = map { delete $params{$_} } @specified_params;
+
+    my @bad_params = keys %params;
+    if (@bad_params) {
+        Carp::croak('invalid params: ' . join(', ', @bad_params));
+    }
+
+    my @missing_params = grep { not exists $values{$_} } @required_params_for_register;
+    if (@missing_params) {
+        Carp::croak('missing required params: ' . join(', ', @missing_params));
+    }
+
+    my @undef_values = grep { not defined $values{$_} } keys %values;
+    if (@undef_values) {
+        Carp::croak('undefined values: ' . join(', ', @undef_values));
+    }
+
+    my $subject_class_name = $values{subject_class_name};
+    my $subject_class_meta = eval { $subject_class_name->__meta__ };
+    if ($@) {
+        Carp::croak("Can't create observer with subject_class_name '$subject_class_name': Can't get class metadata for class '$subject_class_name': $@");
+    }
+    unless ($subject_class_meta) {
+        Carp::croak("Class $subject_class_name cannot be the subject class for an observer because there is no class metadata");
+    }
+
+    my $aspect = $values{aspect};
+    my $subject_id = $values{subject_id};
+    unless ($subject_class_meta->_is_valid_signal($aspect)) {
+        my $croak =  sub { Carp::croak("'$aspect' is not a valid aspect for class $subject_class_name") };
+        unless ($subject_class_name->can('validate_subscription')) {
+            $croak->();
+        }
+        unless ($subject_class_name->validate_subscription($aspect, $subject_id, $values{callback})) {
+            $croak->();
+        }
+    }
+
+    $class->_insert_record_into_all_change_subscriptions(
+        @values{qw(subject_class_name aspect subject_id)},
+        [@values{qw(callback note priority id once)}],
+    );
+
+    return $values{id};
+}
 
 sub _insert_record_into_all_change_subscriptions {
     my($class,$subject_class_name, $aspect,$subject_id, $new_record) = @_;

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -88,10 +88,6 @@ sub _create_or_define {
         Carp::croak('Instantiating a UR::Observer with some method other than create() or __define__() is not supported');
     }
     $self->{callback} = $callback;
-
-    my %params = $rule->params_list;
-    my ($subscription, $delete_subscription);
-
     $self->_insert_record_into_all_change_subscriptions($subject_class_name, $aspect, $subject_id,
                                                         [$callback, $self->note, $self->priority, $self->id, $self->once]);
 

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -43,19 +43,15 @@ sub __define__ {
 sub _create_or_define {
     my $class = shift;
     my $method = shift;
+    my %params = @_;
 
-    my ($rule,%extra) = UR::BoolExpr->resolve($class,@_);
-    my $callback = delete $extra{callback};
+    my $callback = delete $params{callback};
     unless ($callback) {
         $class->error_message("'callback' is a required parameter for creating UR::Observer objects");
         return;
     }
-    if (%extra) {
-        $class->error_message("Cannot create observer.  Class $class has no property ".join(',',keys %extra));
-        return;
-    }
 
-    my $subject_class_name = $rule->value_for('subject_class_name');
+    my $subject_class_name = $params{subject_class_name};
     my $subject_class_meta = eval { $subject_class_name->__meta__ };
     if ($@) {
         $class->error_message("Can't create observer with subject_class_name '$subject_class_name': Can't get class metadata for class '$subject_class_name': $@");
@@ -66,8 +62,8 @@ sub _create_or_define {
         return;
     }
 
-    my $aspect = $rule->value_for('aspect');
-    my $subject_id = $rule->value_for('subject_id');
+    my $aspect = $params{aspect};
+    my $subject_id = $params{subject_id};
     unless ($subject_class_meta->_is_valid_signal($aspect)) {
         if ($subject_class_name->can('validate_subscription') and ! $subject_class_name->validate_subscription($aspect, $subject_id, $callback)) {
             $class->error_message("'$aspect' is not a valid aspect for class $subject_class_name");
@@ -81,9 +77,9 @@ sub _create_or_define {
 
     my $self;
     if ($method eq 'create') {
-        $self = $class->SUPER::create($rule);
+        $self = $class->SUPER::create(%params);
     } elsif ($method eq '__define__') {
-        $self = $class->SUPER::__define__($rule->params_list);
+        $self = $class->SUPER::__define__(%params);
     } else {
         Carp::croak('Instantiating a UR::Observer with some method other than create() or __define__() is not supported');
     }

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -212,7 +212,7 @@ UR::Observer - bind callbacks to object changes
     );
 
     $observer2 = UR::Observer->create(
-        subject_class => 'Acme::Rocket',
+        subject_class_name => 'Acme::Rocket',
         subject_id    => $rocket->id,
         aspect => 'fuel_level',
         callback =>

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -409,12 +409,12 @@ class.
     my $obj = My::Class->create(prop_a => 1);
     $obj->__signal_observers__('custom');  # not an error
 
-To help catch typos, creating an observer for a non-standard aspect generates
-an error message but not an exception, unless the named aspect is in the
-list of 'valid_signals' in the class metadata.  Nothing in the system will
-trigger these observers, but they can be triggered in your own code using the
-C<__signal_observers()__> class or object method.  Sending a signal for an
-aspect that no observers are watching for is not an error.
+To help catch typos, creating an observer for a non-standard aspect throws an
+exception unless the named aspect is in the list of 'valid_signals' in the
+class metadata.  Nothing in the system will trigger these observers, but they
+can be triggered in your own code using the C<__signal_observers()__> class or
+object method.  Sending a signal for an aspect that no observers are watching
+for is not an error.
 
 =cut
 

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -9,7 +9,7 @@ our $VERSION = "0.43"; # UR $VERSION;
 UR::Object::Type->define(
     class_name => __PACKAGE__,
     has => [
-        subject_class_name => { is => 'Text',    is_optional => 1, default_value => '' },
+        subject_class_name => { is => 'Text',    is_optional => 1, default_value => 'UR::Object' },
         subject_id         => { is => 'SCALAR',  is_optional => 1, default_value => '' },
         aspect             => { is => 'String',  is_optional => 1, default_value => '' },
         priority           => { is => 'Number',  is_optional => 1, default_value => 1  },

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -3,7 +3,11 @@ package UR::Observer;
 use strict;
 use warnings;
 
-require UR;
+BEGIN {
+    require UR;
+    require UR::Context::Transaction;
+};
+
 our $VERSION = "0.43"; # UR $VERSION;
 
 UR::Object::Type->define(

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -42,6 +42,7 @@ sub __define__ {
 }
 
 my @required_params_for_register = qw(aspect callback note once priority subject_class_name subject_id id);
+sub required_params_for_register { @required_params_for_register }
 
 sub _create_or_define {
     my $class = shift;
@@ -70,6 +71,7 @@ sub _create_or_define {
 
 {
     my @has_defaults = qw(aspect note once priority subject_class_name subject_id);
+    sub has_defaults { @has_defaults }
     my %defaults =
         map {
             $_ => __PACKAGE__->__meta__->{has}->{$_}->{default_value}
@@ -78,6 +80,7 @@ sub _create_or_define {
             exists __PACKAGE__->__meta__->{has}->{$_}
             && exists __PACKAGE__->__meta__->{has}->{$_}->{default_value}
         } @has_defaults;
+    sub defaults_for_register_callback { %defaults }
     sub register_callback {
         my $class = shift;
         my %params = @_;

--- a/lib/UR/Observer.pm
+++ b/lib/UR/Observer.pm
@@ -16,8 +16,6 @@ UR::Object::Type->define(
         priority           => { is => 'Number',  is_optional => 1, default_value => 1  },
         note               => { is => 'String',  is_optional => 1, default_value => '' },
         once               => { is => 'Boolean', is_optional => 1, default_value => 0  },
-
-        subject_class      => { is => 'UR::Object::Type', id_by => 'subject_class_name' },
         subject            => { is => 'UR::Object', id_by => 'subject_id', id_class_by => 'subject_class_name' },
     ],
     is_transactional => 1,

--- a/t/URT/t/21_observer.t
+++ b/t/URT/t/21_observer.t
@@ -11,7 +11,7 @@ use Test::More tests => 42;
 UR::Object::Type->define(
     class_name => 'URT::Parent',
     is_abstract => 1,
-    valid_signals => ['something_else'],
+    valid_signals => [qw(last_name something_else)],
 );
 
 UR::Object::Type->define(

--- a/t/URT/t/21i_defaults.t
+++ b/t/URT/t/21i_defaults.t
@@ -1,0 +1,125 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use UR;
+
+use Test::More tests => 3;
+use Test::Fatal qw(exception);
+
+use_ok('UR::Observer');
+
+subtest 'defaults' => sub {
+    plan tests => 4;
+
+    my @has_defaults = UR::Observer->has_defaults;
+    ok(@has_defaults > 0, 'got has_defaults');
+
+    my $o = UR::Observer->create(callback => sub {});
+    isa_ok($o, 'UR::Observer', '$o');
+    my @observer_args = map { $o->$_ } @has_defaults;
+
+    my @register_callback_args;
+    {
+        no warnings qw(redefine);
+        local *UR::Observer::_insert_record_into_all_change_subscriptions = sub {
+            my $class = shift;
+            my %values;
+            @values{qw(subject_class_name aspect subject_id)} = (shift, shift, shift);
+            my $list = shift;
+            @values{qw(callback note priority id once)} = @$list;
+            @register_callback_args = @values{@has_defaults};
+        };
+        my $oid = UR::Observer->register_callback(callback => sub {});
+        ok($oid, 'registered callback');
+    }
+
+    is_deeply(\@register_callback_args, \@observer_args, 'register_callback gets the same defaults as creating an observer');
+};
+
+subtest 'exceptions' => sub {
+    plan tests => 5;
+
+    subtest 'bad subject_class_name' => sub {
+        plan tests => 3;
+
+        my @o = UR::Observer->get(subject_class_name => 'Foo');
+        is(scalar(@o), 0, 'no observer exists');
+
+        my $exception = exception { UR::Observer->create(callback => sub {}, subject_class_name => 'Foo') };
+        ok($exception, 'got an exception');
+
+        @o = UR::Observer->get(subject_class_name => 'Foo');
+        is(scalar(@o), 0, 'no observer created');
+    };
+
+    subtest 'bad aspect' => sub {
+        plan tests => 3;
+
+        my @o = UR::Observer->get(aspect => 'foo');
+        is(scalar(@o), 0, 'no observer exists');
+
+        my $exception = exception { UR::Observer->create(callback => sub {}, aspect => 'foo') };
+        ok($exception, 'got an exception');
+
+        @o = UR::Observer->get(aspect => 'foo');
+        is(scalar(@o), 0, 'no observer created');
+    };
+
+    subtest 'extra parameter' => sub {
+        plan tests => 3;
+
+        my $id = UR::Object::Type->autogenerate_new_object_id_uuid;
+
+        my @o = UR::Observer->get(id => $id);
+        is(scalar(@o), 0, 'no observer exists');
+
+        my $exception = exception { UR::Observer->create(callback => sub {}, id => $id, foobar => 1) };
+        ok($exception, 'got an exception');
+
+        @o = UR::Observer->get(id => $id);
+        is(scalar(@o), 0, 'no observer created');
+    };
+
+    subtest 'missing callback' => sub {
+        plan tests => 3;
+
+        my $id = UR::Object::Type->autogenerate_new_object_id_uuid;
+
+        my @o = UR::Observer->get(id => $id);
+        is(scalar(@o), 0, 'no observer exists');
+
+        my $exception = exception { UR::Observer->create(id => $id) };
+        ok($exception, 'got an exception');
+
+        @o = UR::Observer->get(id => $id);
+        is(scalar(@o), 0, 'no observer created');
+    };
+
+    subtest 'undef parameters' => sub {
+        my @param_names = grep { $_ ne 'id' } UR::Observer->required_params_for_register;
+        plan tests => scalar(@param_names) + 1;
+
+        ok(@param_names > 0, 'got some param names');
+
+        for my $param_name (@param_names) {
+            my %params = UR::Observer->defaults_for_register_callback;
+            $params{$param_name} = undef;
+            subtest $param_name => sub {
+                plan tests => 3;
+
+                my $id = UR::Object::Type->autogenerate_new_object_id_uuid;
+
+                my @o = UR::Observer->get(id => $id);
+                is(scalar(@o), 0, 'no observer exists');
+
+                my $exception = exception { UR::Observer->create(callback => sub {}, %params) };
+                ok($exception, 'got an exception');
+
+                @o = UR::Observer->get(id => $id);
+                is(scalar(@o), 0, 'no observer created');
+            };
+        }
+    };
+};

--- a/t/URT/t/21j_register_callback.t
+++ b/t/URT/t/21j_register_callback.t
@@ -1,0 +1,35 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use UR;
+
+use Test::More tests => 10;
+
+use_ok('UR::Observer');
+
+my %fired = (
+    a => 0,
+    b => 0,
+);
+my %id = (
+    a => UR::Observer->register_callback(callback => sub { $fired{a}++ }),
+    b => UR::Observer->register_callback(callback => sub { $fired{b}++ }),
+);
+ok($id{a}, q(registered callback 'a'));
+ok($id{b}, q(registered callback 'b'));
+
+UR::Object->__signal_observers__('create');
+is($fired{a}, 1, q(callback 'a' fired No. 1));
+is($fired{b}, 1, q(callback 'b' fired No. 1));
+
+UR::Object->__signal_observers__('create');
+is($fired{a}, 2, q(callback 'a' fired No. 2));
+is($fired{b}, 2, q(callback 'b' fired No. 2));
+
+ok(UR::Observer->unregister_callback(id => $id{a}), q(unregistered callback 'a'));
+
+UR::Object->__signal_observers__('create');
+is($fired{a}, 2, q(callback 'a' did not fire again after unregistering 'a'));
+is($fired{b}, 3, q(callback 'b' did fire again after unregistering 'a'));

--- a/t/URT/t/99_transaction_log_all_changes.t
+++ b/t/URT/t/99_transaction_log_all_changes.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use_ok('UR::Context::Transaction');
+
+subtest 'ensure log_all_changes is turned off after last transaction' => sub {
+    plan tests => 10;
+
+
+    is(scalar(() = UR::Context::Transaction->get()), 0, 'no transactions at start');
+    is($UR::Context::Transaction::log_all_changes, 0, 'log_all_changes is disabled at start');
+    my @tx = UR::Context::Transaction->begin();
+    is($UR::Context::Transaction::log_all_changes, 1, 'beginning outer transaction enabled log_all_changes');
+    push @tx, UR::Context::Transaction->begin();
+    is($UR::Context::Transaction::log_all_changes, 1, 'beginning inner transaction leaves log_all_changes enabled');
+    pop(@tx)->commit();
+    is($UR::Context::Transaction::log_all_changes, 1, 'committing inner transaction leaves log_all_changes enabled');
+    pop(@tx)->commit();
+    is($UR::Context::Transaction::log_all_changes, 0, 'committing outer transaction disables log_all_changes');
+    push @tx, UR::Context::Transaction->begin();
+    is($UR::Context::Transaction::log_all_changes, 1, 'beginning a new first transaction enabled log_all_changes');
+    push @tx, UR::Context::Transaction->begin();
+    is($UR::Context::Transaction::log_all_changes, 1, 'beginning inner transaction leaves log_all_changes enabled');
+    pop(@tx)->rollback();
+    is($UR::Context::Transaction::log_all_changes, 1, 'rolling back inner transaction leaves log_all_changes enabled');
+    pop(@tx)->rollback();
+    is($UR::Context::Transaction::log_all_changes, 0, 'rolling back outer transaction disables log_all_changes');
+};


### PR DESCRIPTION
- Refactors rollback implementation so classes can override default behavior.
- Exposes a new API to create persistent (across rollbacks) observers.