### PR TITLE
Fix TravisCI failures

### DIFF
--- a/t/URT/t/04h_default_datasource.t
+++ b/t/URT/t/04h_default_datasource.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 5;
+use Test::Exception;
 
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
@@ -119,7 +120,7 @@ subtest 'save' => sub {
 };
 
 subtest 'failure syncing' => sub {
-    plan tests => 7;
+    plan tests => 3;
 
     class URT::FailSync {
         data_source => 'UR::DataSource::Default',
@@ -133,15 +134,12 @@ subtest 'failure syncing' => sub {
         my $should_fail_during_rollback = 0;
         local *URT::FailSync::__rollback__= sub {
             die "failed during rollback" if $should_fail_during_rollback;
-            1;
         };
 
         my $obj = URT::FailSync->create(id => 1);
-        local $@;
-        ok(! eval { UR::Context->current->commit() }, 'failed in commit');
-
-        like($@, qr/failed during save/, 'Exception message includes message from __save__');
-        unlike($@, qr/failed during rollback/, 'Exception message does not include message from __commit__');
+        throws_ok { UR::Context->current->commit() }
+            qr/failed during save/,
+            'Failed in commit';
 
         my $error_message_during_commit;
         UR::DataSource::Default->dump_error_messages(0);
@@ -154,10 +152,9 @@ subtest 'failure syncing' => sub {
             },
         );
         $should_fail_during_rollback = 1;
-        ok(! eval { UR::Context->current->commit() }, 'failed in commit second time');
-
-        like($@, qr/failed during save/, 'Exception message includes message from __save__');
-        like($@, qr/failed during rollback/, 'Exception message includes message from __commit__');
+        throws_ok { UR::Context->current->commit() }
+            qr/Failed to save, and ERRORS DURING ROLLBACK:\s+failed during save.*failed during rollback/s,
+            'Failed in commit second time';
         like($error_message_during_commit,
              qr/Rollback failed:.*'id' => 1/s,
             'error_message() mentions the object failed rollback');


### PR DESCRIPTION
A commit in the observer-refactoring branch caused the default datasource test to fail.

The test failure wasn't caught until merge time because both branches were out for code review at the time.