### PR TITLE
UR::Context::Transaction is getting original object due to an `unload` change

### DIFF
--- a/lib/UR/Change.pm
+++ b/lib/UR/Change.pm
@@ -19,6 +19,34 @@ UR::Object::Type->define(
     is_transactional => 1,
 );
 
+sub changed_object {
+    my $self = shift;
+    my $changed_obj;
+    my $changed_aspect = $self->changed_aspect;
+    if ($changed_aspect eq "delete" or $changed_aspect eq "unload") {
+        my $undo_data = $self->undo_data;
+        unless (defined $undo_data) {
+            $undo_data = '';
+        }
+        $changed_obj = eval "no strict; no warnings; " . $undo_data;
+        my $error = $@;
+        bless($changed_obj, 'UR::DeletedRef') if (ref $changed_obj); # changed class so that UR::Object::DESTROY is not called on a "fake" UR::Object
+        if ($error) {
+            Carp::confess("Error reconstructing $changed_aspect data for @_: $error");
+        }
+    }
+    else {
+        $changed_obj = $self->changed_class_name->get($self->changed_id);
+    }
+
+    if (defined $changed_obj) {
+        return $changed_obj;
+    }
+    else {
+        return;
+    }
+}
+
 sub undo {
     my $self = shift;
     my $changed_class_name = $self->changed_class_name;
@@ -52,19 +80,8 @@ sub undo {
         }
     }
 
-    my $changed_obj;
-    if ($changed_aspect eq "delete" or $changed_aspect eq "unload") {
-        $undo_data = '' unless defined $undo_data;
-        $changed_obj = eval "no strict; no warnings; " . $undo_data;
-        bless($changed_obj, 'UR::DeletedRef') if (ref $changed_obj); # changed class so that UR::Object::DESTROY is not called on a "fake" UR::Object
-        if ($@) {
-            Carp::confess("Error reconstructing $changed_aspect data for @_: $@");
-        }
-        return unless $changed_obj;
-    }
-    else {
-        $changed_obj = $changed_class_name->get($changed_id);
-    }
+    my $changed_obj = $self->changed_object();
+    return unless $changed_obj;
     # TODO: if no changed object, die?
 
 

--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -280,7 +280,9 @@ sub changes_can_be_saved {
     # TODO: limit to objects that changed within transaction as to not duplicate
     # error checking unnecessarily.
 
-    my @changed_objects = map { $_->changed_class_name->get($_->changed_id) } $self->get_changes();
+    my @changed_objects =
+        grep { ! $_->isa('UR::DeletedRef') }
+        map  { $_->changed_object() } $self->get_changes();
 
     # This is primarily to catch custom validity logic in class overrides.
     my @invalid = grep { $_->__errors__ } @changed_objects;

--- a/t/URT/t/99_transaction_unload.t
+++ b/t/URT/t/99_transaction_unload.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use File::Basename;
+use lib File::Basename::dirname(__FILE__)."/../../../lib";
+use lib File::Basename::dirname(__FILE__)."/../..";
+use URT; # dummy namespace
+
+use Test::More tests => 3;
+
+subtest 'setup' => sub {
+    plan tests => 3;
+
+    my $dbh = URT::DataSource::SomeSQLite->get_default_handle;
+    ok($dbh->do('CREATE TABLE person (id integer PRIMARY KEY, name text)'),
+        'created table (person)');
+    ok($dbh->do('INSERT INTO person (id, name) VALUES (1, NULL)'),
+        'inserted person 1');
+
+    my $meta = UR::Object::Type->__define__(
+        class_name => 'URT::Person',
+        id_by => [
+            id => { is => 'Integer' },
+        ],
+        has => {
+            name => { is => 'Text' },
+        },
+        data_source => 'URT::DataSource::SomeSQLite',
+        table_name => 'person',
+    );
+    ok($meta, 'defined a class');
+};
+
+
+my $person = URT::Person->get(1);
+ok(scalar($person->__errors__), 'created a person with errors');
+my $tx = UR::Context::Transaction->begin();
+URT::Person->unload();
+ok($tx->commit, 'committed after unloading erroneous Person');
+


### PR DESCRIPTION
The recently changed code in `UR::Context::Transaction` is getting all changed
objects incorrectly.  In the case of an `unload` it is re-getting the original
object instead of the deleted object.