### PR TITLE
Error out if the user asked to not verify but they selected too many items.

### DIFF
--- a/lib/Command/Dispatch/Shell.pm
+++ b/lib/Command/Dispatch/Shell.pm
@@ -806,6 +806,10 @@ sub resolve_param_value_from_cmdline_text {
         if (!$pmeta->{'is_many'} && @results > 1) {
             $MESSAGE .= "\n" if ($MESSAGE);
             $MESSAGE .= "'$param_name' expects only one result.";
+
+            if ($ENV{UR_NO_REQUIRE_USER_VERIFY}) {
+                die "$MESSAGE\n";
+            }
         }
         @results = $self->_get_user_verification_for_param_value($param_name, @results);
     }


### PR DESCRIPTION
I had set `UR_NO_REQUIRE_USER_VERIFY` in a shell.  I accidentally specified something that matched multiple items in a command.  It produced an infinite loop of `The IDs for your selection are:` messages.  With this change instead an error appears:

```
'build' may require verification...
Resolving parameter 'build' from command argument 'model.name=foo'... found 3
ERROR: build: Errors while resolving from model.name=foo: 'build' expects only one result.
ERROR: build: Problem resolving from model.name=foo.
```
