### PR TITLE
Fix a bug involving the AutoUnloadPool and iterators

### DIFF
--- a/lib/UR/Context/AutoUnloadPool.pm
+++ b/lib/UR/Context/AutoUnloadPool.pm
@@ -74,7 +74,9 @@ sub _unload_objects {
         next unless $objs_for_class;
         foreach ( @$objs_for_class{ keys %{$self->{pool}->{$class_name}}} ) {
             next unless $_;
+            next if $_->__is_buffered;
             print STDERR ($is_subsequent_obj++ ? ", " : ''), $_->id,"\n" if _is_printing_debug();
+            local $@;
             unless (eval { $_->unload(); 1; } ) {
                 push @unload_exceptions, $@;
             }

--- a/lib/UR/Context/ImportIterator.pm
+++ b/lib/UR/Context/ImportIterator.pm
@@ -800,6 +800,8 @@ sub _create_import_iterator_for_underlying_context {
 
         my $retval = $next_object_to_return;
         $next_object_to_return = $primary_object_for_next_db_row;
+        $next_object_to_return->__is_buffered(1) if ($next_object_to_return && $next_object_to_return->isa('UR::Object'));
+        $retval->__is_buffered(0) if ($retval && $retval->isa('UR::Object'));
         return $retval;
     };
 

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -645,6 +645,23 @@ sub __extend_namespace__ {
 
 # Handling of references within the current process
 
+# A flag set/cleared by the Import Iterator to indicate whether this object is
+# being buffered and hasn't been returned to the user yet.  The AutoUnloadPool
+# will skip unloading buffered objects.
+sub __is_buffered {
+    my $self = shift;
+    if (@_) {
+        my $val = shift;
+        if ($val) {
+            $self->{__buffered} = $val;
+        } else {
+            delete $self->{__buffered};
+        }
+    }
+    return $self->{__buffered};
+}
+
+
 sub is_weakened {
     my $self = shift;
     return (exists $self->{__weakened} && $self->{__weakened});


### PR DESCRIPTION
The Context Loading Iterator buffers one object to ensure that all the joined
rows have been loaded before returning the primary object via the iterator.
This interacted badly with the AutoUnloadPool when the pool was created before
the object was pulled off of the iterator by also unloading the buffered object.

Now, the Loading Iterator sets a flag on the buffered object that tells the
AutoUnloadPool to skip unloading that object.  The flag is cleared before the
object gets returned up the stack.