### PR TITLE
Fix a bug involving the AutoUnloadPool and iterators (second attempt)

### DIFF
--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -46,6 +46,7 @@ our $cache_last_prune_serial ||= 0;           # serial number the last time we p
 our $cache_size_highwater;                    # high water mark for cache size.  Start pruning when $all_objects_cache_size goes over
 our $cache_size_lowwater;                     # low water mark for cache size
 our $GET_COUNTER = 1;                         # This is where the serial number for the __get_serial key comes from
+our $light_cache = 0;                         # whether refs in all_objects_loaded should be weak
 
 # For bootstrapping.
 $UR::Context::current = __PACKAGE__;
@@ -77,9 +78,9 @@ sub _initialize_for_current_process {
     $UR::Context::process = UR::Context::Process->_create_for_current_process(parent_id => $UR::Context::base->id);
 
     if (exists $ENV{'UR_CONTEXT_CACHE_SIZE_LOWWATER'} || exists $ENV{'UR_CONTEXT_CACHE_SIZE_HIGHWATER'}) {
-        $UR::Context::destroy_should_clean_up_all_objects_loaded = 1;
         $cache_size_highwater = $ENV{'UR_CONTEXT_CACHE_SIZE_HIGHWATER'} || 0;
         $cache_size_lowwater = $ENV{'UR_CONTEXT_CACHE_SIZE_LOWWATER'} || 0;
+        manage_objects_may_go_out_of_scope();
     }
 
 
@@ -92,6 +93,29 @@ sub _initialize_for_current_process {
 
     $initialized = 1;
     return $UR::Context::current;
+}
+
+# whether some UR objects might go out of scope, for example if pruning is on,
+# light cache is on, or an AutoUnloadPool is alive
+my $objects_may_go_out_of_scope = 0;
+sub objects_may_go_out_of_scope {
+    if (@_) {
+        $objects_may_go_out_of_scope = shift;
+    }
+    return $objects_may_go_out_of_scope;
+}
+
+sub manage_objects_may_go_out_of_scope {
+    if ((defined($cache_size_highwater) and $cache_size_highwater > 0)
+        or
+        $light_cache
+        or
+        UR::Context::AutoUnloadPool->_pool_count
+    ) {
+        objects_may_go_out_of_scope(1);
+    } else {
+        objects_may_go_out_of_scope(0);
+    }
 }
 
 
@@ -278,10 +302,10 @@ sub resolve_data_source_for_object {
 
 sub _light_cache {
     if (@_ > 1) {
-        $UR::Context::light_cache = $_[1];
-        $UR::Context::destroy_should_clean_up_all_objects_loaded = $UR::Context::light_cache;
+        $light_cache = $_[1];
+        manage_objects_may_go_out_of_scope();
     }
-    return $UR::Context::light_cache;
+    return $light_cache;
 }
 
 
@@ -1138,7 +1162,7 @@ sub _construct_object {
     $UR::Context::all_objects_loaded->{$class}{$id} = $object;
 
     # If we're using a light cache, weaken the reference.
-    if ($UR::Context::light_cache) { # and substr($class,0,5) ne 'App::') {
+    if ($light_cache) { # and substr($class,0,5) ne 'App::') {
         Scalar::Util::weaken($UR::Context::all_objects_loaded->{$class}->{$id});
     }
 
@@ -1371,12 +1395,9 @@ sub object_cache_size_highwater {
                 Carp::confess("Can't set the highwater mark less than or equal to the lowwater mark");
                 return;
             }
-            $UR::Context::destroy_should_clean_up_all_objects_loaded = 1;
             $self->prune_object_cache();
-        } else {
-            # turn it off
-            $UR::Context::destroy_should_clean_up_all_objects_loaded = 0;
         }
+        manage_objects_may_go_out_of_scope();
     }
     return $cache_size_highwater;
 }

--- a/lib/UR/Context/AutoUnloadPool.pm
+++ b/lib/UR/Context/AutoUnloadPool.pm
@@ -87,19 +87,6 @@ sub _unload_objects {
     delete $self->{pool};
 }
 
-sub _unload_single_object {
-    my $obj = shift;
-
-    if ($obj->is_prunable) {
-        my($class,$id) = ($obj->class, $obj->id);
-        my @indexes = UR::Object::Index->get(indexed_class_name => $class);
-        do { $_->weaken_reference_for_object($obj) } foreach @indexes;
-        Scalar::Util::weaken($UR::Context::all_objects_loaded->{$class}->{$id});
-    }
-    return 1;
-}
-
-
 sub DESTROY {
     local $@;
 

--- a/lib/UR/Context/AutoUnloadPool.pm
+++ b/lib/UR/Context/AutoUnloadPool.pm
@@ -75,7 +75,7 @@ sub _unload_objects {
         foreach ( @$objs_for_class{ keys %{$self->{pool}->{$class_name}}} ) {
             next unless $_;
             print STDERR ($is_subsequent_obj++ ? ", " : ''), $_->id,"\n" if _is_printing_debug();
-            unless (eval { $_->unload(); 1; } ) {
+            unless (eval { _unload_single_object($_); } ) {
                 push @unload_exceptions, $@;
             }
         }
@@ -85,6 +85,14 @@ sub _unload_objects {
 
     die join("\n", 'The following exceptions happened while unloading:', @unload_exceptions) if @unload_exceptions;
 }
+
+sub _unload_single_object {
+    my $obj = shift;
+
+    $obj->unload;
+    return 1;
+}
+
 
 sub DESTROY {
     local $@;

--- a/lib/UR/Context/AutoUnloadPool.pm
+++ b/lib/UR/Context/AutoUnloadPool.pm
@@ -97,7 +97,12 @@ sub _unload_objects {
 sub _unload_single_object {
     my $obj = shift;
 
-    $obj->unload;
+    if ($obj->is_prunable) {
+        my($class,$id) = ($obj->class, $obj->id);
+        my @indexes = UR::Object::Index->get(indexed_class_name => $class);
+        do { $_->weaken_reference_for_object($obj) } foreach @indexes;
+        Scalar::Util::weaken($UR::Context::all_objects_loaded->{$class}->{$id});
+    }
     return 1;
 }
 

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -740,11 +740,11 @@ sub DESTROY {
     # Handle weak references in the object cache.
     my $obj = shift;
 
-    # $destroy_should_clean_up_all_objects_loaded will be true if either light_cache is on, or
+    # objects_may_go_out_of_scope will be true if either light_cache is on, or
     # the cache_size_highwater mark is a valid value
     my($class, $id) = (ref($obj), $obj->{id});
 
-    if ($UR::Context::destroy_should_clean_up_all_objects_loaded) {
+    if (UR::Context::objects_may_go_out_of_scope()) {
         my $obj_from_cache = delete $UR::Context::all_objects_loaded->{$class}{$id};
         if ($obj->__meta__->is_meta_meta or @{[$obj->__changes__]}) {
             die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$id!" unless $obj eq $obj_from_cache;

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -762,7 +762,7 @@ sub DESTROY {
         }
         else {
             if ($ENV{'UR_DEBUG_OBJECT_RELEASE'}) {
-                print STDERR "MEM DESTROY object $obj class $class if $id\n";
+                print STDERR "MEM DESTROY object $obj class $class id $id\n";
             }
             $obj->unload();
             return $obj->SUPER::DESTROY();

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -742,18 +742,19 @@ sub DESTROY {
 
     # $destroy_should_clean_up_all_objects_loaded will be true if either light_cache is on, or
     # the cache_size_highwater mark is a valid value
+    my($class, $id) = (ref($obj), $obj->{id});
+
     if ($UR::Context::destroy_should_clean_up_all_objects_loaded) {
-        my $class = ref($obj);
-        my $obj_from_cache = delete $UR::Context::all_objects_loaded->{$class}{$obj->{id}};
+        my $obj_from_cache = delete $UR::Context::all_objects_loaded->{$class}{$id};
         if ($obj->__meta__->is_meta_meta or @{[$obj->__changes__]}) {
-            die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$obj->{id}!" unless $obj eq $obj_from_cache;
-            $UR::Context::all_objects_loaded->{$class}{$obj->{id}} = $obj;
+            die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$id!" unless $obj eq $obj_from_cache;
+            $UR::Context::all_objects_loaded->{$class}{$id} = $obj;
             print "KEEPING $obj.  Found $obj .\n";
             return;
         }
         else {
             if ($ENV{'UR_DEBUG_OBJECT_RELEASE'}) {
-                print STDERR "MEM DESTROY object $obj class ",$obj->class," id ",$obj->id,"\n";
+                print STDERR "MEM DESTROY object $obj class $class if $id\n";
             }
             $obj->unload();
             return $obj->SUPER::DESTROY();
@@ -761,7 +762,7 @@ sub DESTROY {
     }
     else {
         if ($ENV{'UR_DEBUG_OBJECT_RELEASE'}) {
-            print STDERR "MEM DESTROY object $obj class ",$obj->class," id ",$obj->id,"\n";
+            print STDERR "MEM DESTROY object $obj class $class id $id\n";
         }
         $obj->SUPER::DESTROY();
     }

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -749,8 +749,15 @@ sub DESTROY {
         refaddr($UR::Context::all_objects_loaded->{$class}{$id}) == refaddr($obj)
     ) {
         # This object was dropped by the cache pruner or an AutoUnloadPool
-        $obj->unload();
-        return $obj->SUPER::DESTROY();
+        if (() = $obj->__changes__) {
+            print STDERR "MEM DESTROY keeping changed object $class id $id\n" if $ENV{'UR_DEBUG_OBJECT_RELEASE'};
+            $UR::Context::all_objects_loaded->{$class}{$id} = $obj;
+            return;
+        } else {
+            print STDERR "MEM DESTROY object $obj class $class if $id\n" if $ENV{'UR_DEBUG_OBJECT_RELEASE'};
+            $obj->unload();
+            return $obj->SUPER::DESTROY();
+        }
     }
     elsif (UR::Context::objects_may_go_out_of_scope()) {
         my $obj_from_cache = delete $UR::Context::all_objects_loaded->{$class}{$id};

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -762,7 +762,7 @@ sub DESTROY {
     elsif (UR::Context::objects_may_go_out_of_scope()) {
         my $obj_from_cache = delete $UR::Context::all_objects_loaded->{$class}{$id};
         if ($obj->__meta__->is_meta_meta or @{[$obj->__changes__]}) {
-            die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$id!" unless $obj eq $obj_from_cache;
+            die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$id!" unless refaddr($obj) == refaddr($obj_from_cache);
             $obj->_save_object_from_destruction();
             print "KEEPING $obj.  Found $obj .\n";
             return;

--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -764,7 +764,7 @@ sub DESTROY {
         if ($obj->__meta__->is_meta_meta or @{[$obj->__changes__]}) {
             die "Object found in all_objects_loaded does not match destroyed ref/id! $obj/$id!" unless refaddr($obj) == refaddr($obj_from_cache);
             $obj->_save_object_from_destruction();
-            print "KEEPING $obj.  Found $obj .\n";
+            print "MEM DESTROY Keeping infrastructure/changed object $obj class $class if $id\n" if $ENV{'UR_DEBUG_OBJECT_RELEASE'};
             return;
         }
         else {

--- a/t/URT/t/04f_filemux.t
+++ b/t/URT/t/04f_filemux.t
@@ -57,16 +57,16 @@ while (my $obj = $iter->next()) {
 my @file_data_sources = UR::DataSource::File->is_loaded();
 is(scalar(@file_data_sources), 2, 'Two file data sources were defined');
 @file_data_sources = ();
-my @warnings;
-{
+do {
     my @warnings = ();
     local $SIG{'__WARN__'} = sub { push @warnings, @_ };
     UR::Context->object_cache_size_lowwater(1);
     UR::Context->object_cache_size_highwater(2);
     ok(UR::Context->current->prune_object_cache(), 'Force object cache pruning');
-}
-@warnings = grep { $_ !~ m/After seceral passes of pruning the object cache, there are still \d+ objects/ } @warnings;
-is(scalar(@warnings), 0, 'No unexpected warnings from pruning');
+    @warnings = grep { $_ !~ m/After several passes of pruning the object cache, there are still \d+ objects/ } @warnings;
+    is(scalar(@warnings), 0, 'No unexpected warnings from pruning')
+        || diag("Warning messages: ",join("\n", @warnings));
+};
 
 UR::Context->object_cache_size_lowwater(undef);
 UR::Context->object_cache_size_highwater(undef);

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=> 5;
+use Test::More tests=> 6;
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
@@ -40,6 +40,25 @@ subtest 'do not unload changed objects' => sub {
         $changed_thing->changable_prop(1000);
 
         URT::Thing->get($unchanged_id);
+    };
+    ok(URT::Thing->is_loaded($changed_id), 'Changed object did not get unloaded');
+    ok(! URT::Thing->is_loaded($unchanged_id), 'Unchanged object did get unloaded');
+};
+
+subtest 'object destructor does not unload changed objects' => sub {
+    plan tests => 2;
+
+    my $changed_id = 99;
+    my $unchanged_id = 98;
+    do {
+        my $changed_thing;
+        do {
+            my $unloader = UR::Context::AutoUnloadPool->create();
+            $changed_thing = URT::Thing->get($changed_id);
+
+            URT::Thing->get($unchanged_id);
+        };
+        $changed_thing->changable_prop(1000);
     };
     ok(URT::Thing->is_loaded($changed_id), 'Changed object did not get unloaded');
     ok(! URT::Thing->is_loaded($unchanged_id), 'Unchanged object did get unloaded');

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -29,21 +29,20 @@ subtest 'normal operation' => sub {
     }
 };
 
-subtest 'exception while unloading' => sub {
+subtest 'do not unload changed objects' => sub {
     plan tests => 2;
 
     my $changed_id = 99;
     my $unchanged_id = 98;
     do {
         my $unloader = UR::Context::AutoUnloadPool->create();
-        my $thing = URT::Thing->get($changed_id);
-        $thing->changable_prop(1000);
+        my $changed_thing = URT::Thing->get($changed_id);
+        $changed_thing->changable_prop(1000);
 
         URT::Thing->get($unchanged_id);
     };
     ok(URT::Thing->is_loaded($changed_id), 'Changed object did not get unloaded');
     ok(! URT::Thing->is_loaded($unchanged_id), 'Unchanged object did get unloaded');
-
 };
 
 subtest 'call delete on pool' => sub {

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=> 4;
+use Test::More tests=> 5;
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
@@ -71,18 +71,48 @@ subtest 'does not unload meta objects' => sub {
         "Class' property object is still loaded");
 };
 
+subtest 'with iterator' => sub {
+    URT::Thing->unload();
+    URT::Related->unload();
+
+    plan tests => 5;
+
+    my $iter = URT::Thing->create_iterator();
+    for (my $expected = 1; $expected <= 5; $expected++) {
+        my $unloader = UR::Context::AutoUnloadPool->create();
+        my $obj = $iter->next();
+        is($obj->id, $expected, "Got Thing ID $expected")
+            || diag("Fetched object ID is ".$obj->id);
+    }
+};
+
 sub setup_classes {
     my $generic_loader = sub {
         my($class_name, $rule, $expected_headers) = @_;
-        my $value;
-        foreach my $prop ( $rule->template->_property_names ) {
-            if ($value = $rule->value_for($prop)) {
-                last;
-            }
-        }
+        my $value_width = scalar(@$expected_headers);
 
-        my @value = ($value) x scalar(@$expected_headers);
-        return ($expected_headers, [ \@value ]);
+        if ($rule->template->_property_names) {
+            # get() with filters
+            my $value;
+            foreach my $prop ( $rule->template->_property_names ) {
+                if ($value = $rule->value_for($prop)) {
+                    last;
+                }
+            }
+
+            my @value = ($value) x $value_width;
+            return ($expected_headers, [ \@value ] );
+
+        } else {
+            # get() with no filters
+            # return a closure that will start at '1' and go up
+            my $value = 0;
+            my $iterator = sub {
+                $value++;
+                return [ ($value) x $value_width ];
+            };
+            return ($expected_headers, $iterator);
+        }
     };
 
     class URT::Related {


### PR DESCRIPTION
The Context Loading Iterator buffers one object to ensure that all the joined
rows have been loaded before returning the primary object via the iterator.
This interacted badly with the AutoUnloadPool when the pool was created before
the object was pulled off of the iterator by also unloading the buffered object

This changes the AutoUnloadPool to use the same weakening mechanism that the cache pruner uses.  It fixes the bug because the Loading Iterator maintains a reference to the buffered object, keeping it from getting unloaded until it's not buffered anymore.

This PR supersedes #91 