### PR TITLE
UR::Value inside an AutoUnloadPool

### DIFF
--- a/lib/UR/Object.pm
+++ b/lib/UR/Object.pm
@@ -681,6 +681,7 @@ sub is_prunable {
     return 1 if $self->is_weakened;
     return 0 if $self->__meta__->is_meta;
     return 0 if $self->{__get_serial} && $self->__changes__ && @{[$self->__changes__]};
+    return 0 if $self->isa('UR::Singleton');
     return 1;
 }
 

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -121,7 +121,8 @@ subtest 'works with UR::Value objects' => sub {
 
 subtest 'works with singletons' => sub {
     plan tests => 3;
-    ok(! URT::Singleton->is_loaded(), 'no URT::Singleton loaded');
+    ok(! $URT::Singleton::singleton, 'no URT::Singleton loaded');
+
     my $refaddr;
     do {
         my $unloader = UR::Context::AutoUnloadPool->create();

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests=> 6;
+use Test::More tests=> 7;
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
@@ -102,6 +102,20 @@ subtest 'with iterator' => sub {
         is($obj->id, $expected, "Got Thing ID $expected")
             || diag("Fetched object ID is ".$obj->id);
     }
+};
+
+subtest 'works with UR::Value objects' => sub {
+    plan tests => 4;
+    ok(! UR::Object::Type->is_loaded('UR::Value::Integer'), 'UR::Value::Integer is not loaded yet.');
+    do {
+        my $unloader = UR::Context::AutoUnloadPool->create();
+        my $integer = UR::Value::Integer->get(23);
+        isa_ok($integer, 'UR::Value', 'got value inside pool');
+    };
+
+    ok( UR::Object::Type->is_loaded('UR::Value::Integer'), 'UR::Value::Integer is loaded now.');
+    my $integer = UR::Value::Integer->get(24);
+    isa_ok($integer, 'UR::Value', 'got value outside pool');
 };
 
 sub setup_classes {

--- a/t/URT/t/99-autounload-pool.t
+++ b/t/URT/t/99-autounload-pool.t
@@ -120,14 +120,15 @@ subtest 'works with UR::Value objects' => sub {
 };
 
 subtest 'works with singletons' => sub {
-    plan tests => 3;
-    ok(! $URT::Singleton::singleton, 'no URT::Singleton loaded');
+    plan tests => 4;
+    ok(!defined $URT::Singleton::singleton, 'no URT::Singleton loaded');
 
     my $refaddr;
     do {
         my $unloader = UR::Context::AutoUnloadPool->create();
         my $singleton = URT::Singleton->get();
         isa_ok($singleton, 'UR::Singleton', 'created a singleton');
+        is($singleton, $URT::Singleton::singleton, 'URT::Singleton loaded');
         $refaddr = refaddr($singleton);
     };
     my $singleton = URT::Singleton->get();


### PR DESCRIPTION
In genome/genome#894 I encountered an issue loading `Set`s inside of a `UR::Context::AutoUnloadPool`.  Attached here is a simplified testcase.  Here's the relevant stacktrace:
```
Can't locate object method "get" via package "hostname.edu 5522 1438205291 10022" at lib/UR/Object/Type/InternalAPI.pm line 39
        UR::Object::Type::data_source('UR::Value::Integer::Type=HASH(0x34ff0b8)') called at lib/UR/Context.pm line 268
        UR::Context::resolve_data_sources_for_class_meta_and_rule('UR::Context::Process=HASH(0x3002618)', 'UR::Value::Integer::Type=HASH(0x34ff0b8)', 'UR::BoolExpr=HASH(0x351f3c0)') called at lib/UR/Context.pm line 1749
        UR::Context::get_objects_for_class_and_rule('UR::Context::Process=HASH(0x3002618)', 'UR::Value::Integer', 'UR::BoolExpr=HASH(0x351f3c0)') called at lib/UR/Context.pm line 530
        UR::Context::query('UR::Context::Process=HASH(0x3002618)', 'UR::Value::Integer', 24) called at lib/UR/Object.pm line 24
        UR::Object::get('UR::Value::Integer', 24) called at t/URT/t/99-autounload-pool.t line 117
```