### PR TITLE
External Changes undo() on UR::Context->rollback()

### DIFF
--- a/lib/UR/Change.pm
+++ b/lib/UR/Change.pm
@@ -159,4 +159,15 @@ sub undo {
     return 1;
 }
 
+sub __rollback__ {
+    my $self = shift;
+    my $changed_aspect = $self->changed_aspect;
+    if($changed_aspect eq 'external_change') {
+        $self->undo;
+        $self->delete;
+    } else {
+        return $self->SUPER::__rollback__;
+    }
+}
+
 1;

--- a/t/URT/t/99_transaction-rollback_undoes_external_change.t
+++ b/t/URT/t/99_transaction-rollback_undoes_external_change.t
@@ -5,28 +5,49 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../..";
 
 use URT;
-use Test::More tests => 4;
+use Test::More tests => 2;
 
 UR::Object::Type->define(
     class_name => 'URT::Thing',
     id_by => 'thing_id',
 );
 
-my $thing = URT::Thing->create(thing_id => '1');
+sub run_test {
+    my $use_transaction = shift;
 
-my $undo_call_count = 0;
-my $undo = sub {
-    $undo_call_count++;
+    plan tests => 4;
+
+    my $tx;
+    if($use_transaction) {
+        $tx = UR::Context::Transaction->begin();
+    } else {
+        $tx = 'UR::Context';
+    }
+
+    my $thing = URT::Thing->create(thing_id => '1');
+
+    my $undo_call_count = 0;
+    my $undo = sub {
+        $undo_call_count++;
+    };
+
+    my $c = UR::Context::Transaction->log_change(
+        $thing, $thing->class, $thing->id, 'external_change', $undo
+    );
+    isa_ok($c, 'UR::Change', 'created a change');
+    is($c->undo_data, $undo, 'undo subrountine properly configured');
+
+    $tx->rollback();
+    is($undo_call_count, 1, 'undo fired');
+
+    UR::Context->rollback(); #can't rollback a transaction twice
+    is($undo_call_count, 1, 'undo did not fire again');
+}
+
+subtest 'undo outside transaction' => sub {
+    run_test('0');
 };
 
-my $c = UR::Context::Transaction->log_change(
-    $thing, $thing->class, $thing->id, 'external_change', $undo
-);
-isa_ok($c, 'UR::Change', 'created a change');
-is($c->undo_data, $undo, 'undo subrountine properly configured');
-
-UR::Context->rollback();
-is($undo_call_count, 1, 'undo fired');
-
-UR::Context->rollback();
-is($undo_call_count, 1, 'undo did not fire again');
+subtest 'undo within transaction' => sub {
+    run_test('1');
+};

--- a/t/URT/t/99_transaction-rollback_undoes_external_change.t
+++ b/t/URT/t/99_transaction-rollback_undoes_external_change.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use File::Basename;
+use lib File::Basename::dirname(__FILE__)."/../..";
+
+use URT;
+use Test::More tests => 4;
+
+UR::Object::Type->define(
+    class_name => 'URT::Thing',
+    id_by => 'thing_id',
+);
+
+my $thing = URT::Thing->create(thing_id => '1');
+
+my $undo_call_count = 0;
+my $undo = sub {
+    $undo_call_count++;
+};
+
+my $c = UR::Context::Transaction->log_change(
+    $thing, $thing->class, $thing->id, 'external_change', $undo
+);
+isa_ok($c, 'UR::Change', 'created a change');
+is($c->undo_data, $undo, 'undo subrountine properly configured');
+
+UR::Context->rollback();
+is($undo_call_count, 1, 'undo fired');
+
+UR::Context->rollback();
+is($undo_call_count, 1, 'undo did not fire again');


### PR DESCRIPTION
`UR::Change` objects can be used to record changes made outside the system.  This addresses an issue where `undo()` would only be triggered while running within a `UR::Context::Transaction`.