### PR TITLE
Commit observers with exceptions

### DIFF
--- a/lib/UR/Util.pm
+++ b/lib/UR/Util.pm
@@ -22,6 +22,7 @@ sub on_destroy(&) {
 # used only by the above sub
 # the local $@ ensures that we this does not stomp on thrown exceptions
 sub UR::Util::CallOnDestroy::DESTROY { local $@; shift->(); }
+sub UR::Util::CallOnDestroy::cancel { my $self = shift; bless $self, 'UR::Util::DontCallOnDestroy' }
 
 sub d {
     Data::Dumper->new([@_])->Terse(1)->Indent(0)->Useqq(1)->Dump;

--- a/t/URT/t/001_util_on_destroy.t
+++ b/t/URT/t/001_util_on_destroy.t
@@ -6,7 +6,7 @@ use lib File::Basename::dirname(__FILE__).'/../..';
 
 sub dummy { eval{} };
 
-plan tests => 3;
+plan tests => 4;
 use UR;
 
 subtest basic => sub {
@@ -46,4 +46,15 @@ subtest exception => sub {
     my $exception = $@;
     is($x, 4, "value is updated after the sentry goes out of scope during thrown exception");
     ok($@, "exception is passed through even thogh the sentry does an eval internally: $@");
+};
+
+subtest cancel => sub {
+    plan tests => 2;
+
+    my $x = 1;
+    do {
+        my $sentry = UR::Util::on_destroy { $x = 2; };
+        ok($sentry->cancel(), 'Cancel sentry');
+    };
+    is($x, 1, 'Cancelled sentry did not run');
 };

--- a/t/URT/t/001_util_on_destroy.t
+++ b/t/URT/t/001_util_on_destroy.t
@@ -6,32 +6,44 @@ use lib File::Basename::dirname(__FILE__).'/../..';
 
 sub dummy { eval{} };
 
-plan tests => 7;
+plan tests => 3;
 use UR;
-my $x = 1;
-my $sentry = UR::Util::on_destroy { $x = 2; dummy() };
-is($x, 1, "value is not updated when the sentry has not been destroyed");
-$sentry = undef;
-is($x, 2, "value is updated when the sentry has been destroyed");
 
-$x = 1;
-sub foo {
-    my $sentry = UR::Util::on_destroy { $x = 3; dummy(); };
-    is($x, 1, "value is not updated while the sentry is still in scope");
-}
-foo();
-is($x, 3, "value is updated after the sentry goes out of scope");
+subtest basic => sub {
+    plan tests => 2;
 
-$x = 1;
-sub bar {
-    my $sentry = UR::Util::on_destroy { $x = 4; dummy(); };
-    is($x, 1, "value is updated while the sentry is still in scope");
-    die "ouch";
-}
-eval {
-    bar();
+    my $x = 1;
+    my $sentry = UR::Util::on_destroy { $x = 2; dummy() };
+    is($x, 1, "value is not updated when the sentry has not been destroyed");
+    $sentry = undef;
+    is($x, 2, "value is updated when the sentry has been destroyed");
 };
-my $exception = $@;
-is($x, 4, "value is updated after the sentry goes out of scope during thrown exception");
-ok($@, "exception is passed through even thogh the sentry does an eval internally: $@");
 
+subtest scope => sub {
+    plan tests => 2;
+
+    my $x = 1;
+    my $foo = sub {
+        my $sentry = UR::Util::on_destroy { $x = 3; dummy(); };
+        is($x, 1, "value is not updated while the sentry is still in scope");
+    };
+    $foo->();
+    is($x, 3, "value is updated after the sentry goes out of scope");
+};
+
+subtest exception => sub {
+    plan tests => 3;
+
+    my $x = 1;
+    my $bar = sub {
+        my $sentry = UR::Util::on_destroy { $x = 4; dummy(); };
+        is($x, 1, "value is updated while the sentry is still in scope");
+        die "ouch";
+    };
+    eval {
+        $bar->();
+    };
+    my $exception = $@;
+    is($x, 4, "value is updated after the sentry goes out of scope during thrown exception");
+    ok($@, "exception is passed through even thogh the sentry does an eval internally: $@");
+};


### PR DESCRIPTION
Observers watching the Context commit should fire even if the sync/commit process throws an exception