### PR TITLE
Fatal message

### DIFF
--- a/lib/UR/ModuleBase.pm
+++ b/lib/UR/ModuleBase.pm
@@ -751,9 +751,6 @@ $create_subs_for_message_type = sub {
             # If the callback set $msg to undef with "$_[1] = undef", then they didn't want the message
             # processed further
             if (defined $msg) {
-
-                $self->$messaging_action($msg);
-
                 if ($self->$should_queue_messages()) {
                     my $a = $self->$messages_arrayref();
                     push @$a, $msg;
@@ -764,6 +761,9 @@ $create_subs_for_message_type = sub {
                 $self->$message_file($file);
                 $self->$message_line($line);
                 $self->$message_subroutine($subroutine);
+
+                $self->$messaging_action($msg);
+
             }
         }
 

--- a/lib/UR/ModuleBase.pm
+++ b/lib/UR/ModuleBase.pm
@@ -406,7 +406,7 @@ yet.
 =cut
 
 my $create_subs_for_message_type;  # filled in lower down
-my @message_types = qw(error status warning debug usage);
+my @message_types = qw(error status warning debug usage fatal);
 sub message_types
 {
     my $self = shift;
@@ -430,6 +430,7 @@ my %default_messaging_settings;
 $default_messaging_settings{dump_error_messages} = 1;
 $default_messaging_settings{dump_warning_messages} = 1;
 $default_messaging_settings{dump_status_messages} = 1;
+$default_messaging_settings{dump_fatal_messages} = 1;
 
 #
 # Implement error_mesage/warning_message/status_message in a way

--- a/lib/UR/ModuleBase.pm
+++ b/lib/UR/ModuleBase.pm
@@ -396,7 +396,7 @@ With no arguments, this method returns all the types of messages that
 this class handles.  With arguments, it adds a new type to the
 list.
 
-Standard message types are error, status, warning, debug and usage.
+Standard message types are fatal, error, status, warning, debug and usage.
 
 Note that the addition of new types is not fully supported/implemented
 yet.
@@ -478,6 +478,9 @@ returned.  If the message is C<undef> then no message is printed or queued, and
 the next time error_message is run as an accessor, it will return
 undef.
 
+Note that C<fatal_message()> will throw an exception at the point it appears
+in the program.  This exception, like others, is trappable bi C<eval>.
+
 =item dump_error_messages
 
     $obj->dump_error_messages(0);
@@ -486,6 +489,10 @@ undef.
 Get or set the flag which controls whether messages sent via C<error_message()>
 is printed to the terminal.  This flag defaults to true for warning and error
 messages, and false for others.
+
+Note that C<fatal_message()> messages and exceptions do not honor the value of
+C<dump_fatal_messages()>, and always print their message and throw their
+exception unless trapped with an C<eval>.
 
 =item queue_error_messages
 

--- a/t/URT/t/13a_messaging.t
+++ b/t/URT/t/13a_messaging.t
@@ -7,7 +7,7 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__).'/../..';
 
-use Test::More tests => 828;
+use Test::More tests => 3;
 
 use UR::Namespace::Command::Old::DiffRewrite;
 
@@ -23,142 +23,151 @@ socketpair($UR::ModuleBase::stderr,$stderr_twin, AF_UNIX, SOCK_STREAM, PF_UNSPEC
 $UR::ModuleBase::stderr->autoflush(1);
 $stderr_twin->blocking(0);
 
-my $buffer;
 for my $type (qw/error warning status/) {
-    my $accessor = $type . "_message";
+    subtest "$type message" => sub {
+        plan tests => 9;
 
-    my $uc_type = uc($type);
-    my $msg_prefix = ($type eq "status" ? "" : "$uc_type: ");
+        my $buffer;
+        my $accessor = $type . "_message";
 
-    my $msg_source_sub = $accessor . '_source';
+        my $uc_type = uc($type);
+        my $msg_prefix = ($type eq "status" ? "" : "$uc_type: ");
 
-    for my $do_queue ([],[0],[1]) {
-        for my $do_dump ([],[0],[1]) {
+        my $msg_source_sub = $accessor . '_source';
 
-            my $dump_flag = "dump_" . $type . "_messages";
-            $c->$dump_flag(@$do_dump);
+        for my $do_queue ([],[0],[1]) {
+            for my $do_dump ([],[0],[1]) {
+                my $subtest_do_queue = defined $do_queue->[0] ? $do_queue->[0] : '<undef>';
+                my $subtest_do_dump = defined $do_dump->[0] ? $do_dump->[0] : '<undef>';
+                subtest "queue: $subtest_do_queue, dump: $subtest_do_dump" => sub {
 
-            my $queue_flag = "queue_" . $type . "_messages";
-            $c->$queue_flag(@$do_queue);
+                    my $dump_flag = "dump_" . $type . "_messages";
+                    $c->$dump_flag(@$do_dump);
 
-            my $list_accessor = $accessor . "s";
+                    my $queue_flag = "queue_" . $type . "_messages";
+                    $c->$queue_flag(@$do_queue);
 
-            is($c->$accessor(),         undef ,         "$type starts unset");
-            $buffer = $stderr_twin->getline;
-            is($buffer, undef, "no message");
+                    my $list_accessor = $accessor . "s";
 
-            my $cb_register = $type . "_messages_callback";
-            my $cb_msg_count = 0;
-            my @cb_args;
-            my $callback_sub = sub { @cb_args = @_; $cb_msg_count++;};
-            ok($c->$cb_register($callback_sub), "can set callback");
-            is($c->$cb_register(), $callback_sub, 'can get callback');
+                    is($c->$accessor(),         undef ,         "$type starts unset");
+                    $buffer = $stderr_twin->getline;
+                    is($buffer, undef, "no message");
 
-            my $message_line = __LINE__ + 1;    # The messaging sub will be called on the next line
-            is($c->$accessor("error%d", 1), "error1",       "$type setting works");
-            $buffer = $stderr_twin->getline;
-            is($buffer, ($c->$dump_flag ? "${msg_prefix}error1\n" : undef), ($c->$dump_flag ?  "got message 1" : "no dump") );
+                    my $cb_register = $type . "_messages_callback";
+                    my $cb_msg_count = 0;
+                    my @cb_args;
+                    my $callback_sub = sub { @cb_args = @_; $cb_msg_count++;};
+                    ok($c->$cb_register($callback_sub), "can set callback");
+                    is($c->$cb_register(), $callback_sub, 'can get callback');
 
-            my %source_info = $c->$msg_source_sub();
-            is_deeply(\%source_info,
-                      { $accessor => 'error1',
-                        $type.'_package' => 'main',
-                        $type.'_file' => __FILE__,
-                        $type.'_line' => $message_line,
-                        $type.'_subroutine' => undef },   # not called from within a sub
-                      "$msg_source_sub returns correct info");
+                    my $message_line = __LINE__ + 1;    # The messaging sub will be called on the next line
+                    is($c->$accessor("error%d", 1), "error1",       "$type setting works");
+                    $buffer = $stderr_twin->getline;
+                    is($buffer, ($c->$dump_flag ? "${msg_prefix}error1\n" : undef), ($c->$dump_flag ?  "got message 1" : "no dump") );
 
-            is($cb_msg_count, 1, "$type callback fired");
-            is_deeply(
-                \@cb_args,    [$c, "error1"],       "$type callback got correct args"
-            );
+                    my %source_info = $c->$msg_source_sub();
+                    is_deeply(\%source_info,
+                              { $accessor => 'error1',
+                                $type.'_package' => 'main',
+                                $type.'_file' => __FILE__,
+                                $type.'_line' => $message_line,
+                                $type.'_subroutine' => undef },   # not called from within a sub
+                              "$msg_source_sub returns correct info");
 
-            is($c->$accessor(),         "error1",       "$type returns");
-            $buffer = $stderr_twin->getline;
-            is($buffer, undef, "no dump");
+                    is($cb_msg_count, 1, "$type callback fired");
+                    is_deeply(
+                        \@cb_args,    [$c, "error1"],       "$type callback got correct args"
+                    );
 
-            is($c->$accessor("error2"), "error2",       "$type resetting works");
-            $buffer = $stderr_twin->getline;
-            is($buffer, ($c->$dump_flag ? "${msg_prefix}error2\n" : undef), ($c->$dump_flag ?  "got message 2" : "no dump") );
+                    is($c->$accessor(),         "error1",       "$type returns");
+                    $buffer = $stderr_twin->getline;
+                    is($buffer, undef, "no dump");
 
-            is($cb_msg_count, 2, "$type callback fired");
+                    is($c->$accessor("error2"), "error2",       "$type resetting works");
+                    $buffer = $stderr_twin->getline;
+                    is($buffer, ($c->$dump_flag ? "${msg_prefix}error2\n" : undef), ($c->$dump_flag ?  "got message 2" : "no dump") );
 
-            is($c->$accessor(),         "error2",       "$type returns");
-            is_deeply(
-                \@cb_args,    [$c, "error2"],       "$type callback got correct args"
-            );
+                    is($cb_msg_count, 2, "$type callback fired");
 
-            is_deeply(
-                [$c->$list_accessor],
-                ($c->$queue_flag ? ["error1","error2"] : []),
-                ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
-            );
+                    is($c->$accessor(),         "error2",       "$type returns");
+                    is_deeply(
+                        \@cb_args,    [$c, "error2"],       "$type callback got correct args"
+                    );
 
-            is($c->$accessor(undef),    undef ,         "undef message sent to $type");
+                    is_deeply(
+                        [$c->$list_accessor],
+                        ($c->$queue_flag ? ["error1","error2"] : []),
+                        ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
+                    );
 
-            is($cb_msg_count, 3, "$type callback fired");
+                    is($c->$accessor(undef),    undef ,         "undef message sent to $type");
 
-            $buffer = $stderr_twin->getline;
-            is($buffer, undef, 'Setting undef message results in no output');
+                    is($cb_msg_count, 3, "$type callback fired");
 
-            is($c->$accessor(),         undef ,         "$type still has the previous message");
-            is_deeply(
-                \@cb_args,    [$c, undef],       "$type callback got correct args"
-            );
+                    $buffer = $stderr_twin->getline;
+                    is($buffer, undef, 'Setting undef message results in no output');
 
-            is_deeply(
-                [$c->$list_accessor],
-                ($c->$queue_flag ? ["error1","error2"] : []),
-                ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
-            );
+                    is($c->$accessor(),         undef ,         "$type still has the previous message");
+                    is_deeply(
+                        \@cb_args,    [$c, undef],       "$type callback got correct args"
+                    );
 
-            my $listref_accessor = $list_accessor . "_arrayref";
-            my $listref = $c->$listref_accessor();
-            is_deeply(
-    	        $listref,
-                ($c->$queue_flag ? ['error1','error2'] : []),
-                "$type listref is correct"
-            );
+                    is_deeply(
+                        [$c->$list_accessor],
+                        ($c->$queue_flag ? ["error1","error2"] : []),
+                        ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
+                    );
 
-            $c->$cb_register(sub { $_[1] .= "foo"});
-            $c->$accessor("altered");
-            $buffer = $stderr_twin->getline();
-            is($buffer, ($c->$dump_flag ? "${msg_prefix}alteredfoo\n" : undef), ($c->$dump_flag ?  "got altered message" : "no dump") );
-            is_deeply(
-                [$c->$list_accessor],
-                ($c->$queue_flag ? ["error1","error2","alteredfoo"] : []),
-                ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
-            );
+                    my $listref_accessor = $list_accessor . "_arrayref";
+                    my $listref = $c->$listref_accessor();
+                    is_deeply(
+                        $listref,
+                        ($c->$queue_flag ? ['error1','error2'] : []),
+                        "$type listref is correct"
+                    );
 
-            $c->$cb_register(undef);  # Unset the callback
+                    $c->$cb_register(sub { $_[1] .= "foo"});
+                    $c->$accessor("altered");
+                    $buffer = $stderr_twin->getline();
+                    is($buffer, ($c->$dump_flag ? "${msg_prefix}alteredfoo\n" : undef), ($c->$dump_flag ?  "got altered message" : "no dump") );
+                    is_deeply(
+                        [$c->$list_accessor],
+                        ($c->$queue_flag ? ["error1","error2","alteredfoo"] : []),
+                        ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
+                    );
 
-            is($c->$accessor(undef),    undef ,         "undef message sent to $type message");
-            is($cb_msg_count, 3, "$type callback correctly didn't get fired");
-            $buffer = $stderr_twin->getline();
-            is($buffer, undef, 'Setting undef message results in no output');
-            is_deeply(
-                [$c->$list_accessor],
-                ($c->$queue_flag ? ["error1","error2","alteredfoo"] : []),
-                ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
-            );
+                    $c->$cb_register(undef);  # Unset the callback
 
-            if ($c->$queue_flag) {
-                $listref->[2] = "something else";
-                is_deeply(
-                    [$c->$list_accessor],
-                    ["error1","error2","something else"],
-                    "$type list is correct after changing via the listref"
-                );
+                    is($c->$accessor(undef),    undef ,         "undef message sent to $type message");
+                    is($cb_msg_count, 3, "$type callback correctly didn't get fired");
+                    $buffer = $stderr_twin->getline();
+                    is($buffer, undef, 'Setting undef message results in no output');
+                    is_deeply(
+                        [$c->$list_accessor],
+                        ($c->$queue_flag ? ["error1","error2","alteredfoo"] : []),
+                        ($c->$queue_flag ? "$type list is correct" : "$type list is correctly empty")
+                    );
+
+                    if ($c->$queue_flag) {
+                        $listref->[2] = "something else";
+                        is_deeply(
+                            [$c->$list_accessor],
+                            ["error1","error2","something else"],
+                            "$type list is correct after changing via the listref"
+                        );
 
 
-                @$listref = ();
-                is_deeply(
-                    [$c->$list_accessor],   [],    "$type list cleared out as expected"
-                );
+                        @$listref = ();
+                        is_deeply(
+                            [$c->$list_accessor],   [],    "$type list cleared out as expected"
+                        );
+                    }
+                    done_testing();
+                };
             }
-        }
 
-    }
+        }
+    };
 }
 
 1;


### PR DESCRIPTION
This branch implements $class->fatal_message().  It works just like all the other message types except it throws an exception with Carp::croak() instead of printing to STDERR.  With this, we can simplify all the Genome calls like ```die $self->error_message('foo')```, with ```$self->fatal_message('foo')```, with the added bonus that the message will only be printed once.