### PR TITLE
Change objects an transactions

### DIFF
--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -2625,6 +2625,8 @@ sub commit {
     }
     $self->__signal_change__('commit',1);
 
+    $_->delete foreach UR::Change->get();
+
     foreach ( $self->all_objects_loaded('UR::Object') ) {
         delete $_->{'_change_count'};
     }

--- a/t/URT/t/99_transaction_log_all_changes.t
+++ b/t/URT/t/99_transaction_log_all_changes.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 use_ok('UR::Context::Transaction');
 
@@ -43,6 +43,21 @@ subtest 'undos are not fired by top-level context after software tx completes' =
     );
 
     $tx->commit();
+    UR::Context->rollback();
+    ok('finished');
+};
+
+subtest 'undos are not fired after top-level tx conpletes' => sub {
+    plan tests => 1;
+
+    my $shouldnt_be_called = sub { ok(0, 'undo callback called') };
+
+    my $foo = UR::Value->get(1);
+    UR::Context::Transaction->log_change(
+        $foo, 'UR::Value', 1, 'external_change', $shouldnt_be_called
+    );
+
+    UR::Context->commit();
     UR::Context->rollback();
     ok('finished');
 };

--- a/t/URT/t/99_transaction_log_all_changes.t
+++ b/t/URT/t/99_transaction_log_all_changes.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use_ok('UR::Context::Transaction');
 
@@ -29,4 +29,20 @@ subtest 'ensure log_all_changes is turned off after last transaction' => sub {
     is($UR::Context::Transaction::log_all_changes, 1, 'rolling back inner transaction leaves log_all_changes enabled');
     pop(@tx)->rollback();
     is($UR::Context::Transaction::log_all_changes, 0, 'rolling back outer transaction disables log_all_changes');
+};
+
+subtest 'undos are not fired by top-level context after software tx completes' => sub {
+    plan tests => 1;
+
+    my $shouldnt_be_called = sub { ok(0, 'undo callback called') };
+
+    my $tx = UR::Context::Transaction->begin();
+    my $foo = UR::Value->get(1);
+    UR::Context::Transaction->log_change(
+        $foo, 'UR::Value', 1, 'external_change', $shouldnt_be_called
+    );
+
+    $tx->commit();
+    UR::Context->rollback();
+    ok('finished');
 };


### PR DESCRIPTION
Make sure Change objects are deleted after their scope ends to prevent them from being fired if a later transaction does a rollback().  This should get the remaining model tests to pass.