### PR TITLE
Change objects

### DIFF
--- a/lib/UR/Change.pm
+++ b/lib/UR/Change.pm
@@ -65,7 +65,7 @@ sub undo {
     # Allow reversal of those methods to indirectly reverse ghost changes.
     if ($changed_class_name =~ /::Ghost/) {
         if ($changed_aspect !~ /^(create|delete)(_object|)$/) {
-            Carp::confess("Unlogged change on ghost? @_");
+            Carp::confess("Unlogged change on ghost? $self");
         }
         return 1;
     }
@@ -122,10 +122,10 @@ sub undo {
         if ($changed_obj->isa('UR::Context::Transaction')) {
             UR::Object::unload($changed_obj);
         } else {
-            Carp::confess();
+            Carp::confess(q(Cannot undo 'commit' on a non-software transaction));
         }
     } elsif ($changed_aspect eq "rollback") {
-        Carp::confess();
+        Carp::confess(q(Cannot undo 'rollback'));
     } elsif ($changed_aspect eq 'rewrite_module_header') {
         my $VAR1;
         eval $undo_data;

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -2603,15 +2603,34 @@ sub has_changes {
 }
 
 sub commit {
-    my $self;
-    if (@_) {
-        $self = shift;
-        ref($self) && Carp::croak('UR::Context->commit() must be called as a class method, not an instance method');
-    } else {
-        Carp::carp 'UR::Context::commit() called as a function, not a method.  Assumming commit on current context' unless @_;
+    Carp::carp 'UR::Context::commit() called as a function, not a method.  Assumming commit on current context' unless @_;
+
+    my $self = shift;
+    $self = UR::Context->current() unless ref $self;
+
+    $self->__signal_change__('precommit');
+
+    unless ($self->_sync_databases) {
+        $self->__signal_observers__('sync_databases', 0);
+        $self->__signal_change__('commit',0);
+        return;
     }
-    $self = UR::Context->current();
-    $self->commit();
+
+    $self->__signal_observers__('sync_databases', 1);
+
+    unless ($self->_commit_databases) {
+        $self->__signal_change__('commit',0);
+        die "Application failure during commit!";
+    }
+    $self->__signal_change__('commit',1);
+
+    $_->delete foreach UR::Change->get();
+
+    foreach ( $self->all_objects_loaded('UR::Object') ) {
+        delete $_->{'_change_count'};
+    }
+
+    return 1;
 }
 
 sub rollback {

--- a/lib/UR/Context.pm
+++ b/lib/UR/Context.pm
@@ -2603,33 +2603,15 @@ sub has_changes {
 }
 
 sub commit {
-
-    Carp::carp 'UR::Context::commit() called as a function, not a method.  Assumming commit on current context' unless @_;
-
-    my $self = shift;
-    $self = UR::Context->current() unless ref $self;
-
-    $self->__signal_change__('precommit');
-
-    unless ($self->_sync_databases) {
-        $self->__signal_observers__('sync_databases', 0);
-        $self->__signal_change__('commit',0);
-        return;
+    my $self;
+    if (@_) {
+        $self = shift;
+        ref($self) && Carp::croak('UR::Context->commit() must be called as a class method, not an instance method');
+    } else {
+        Carp::carp 'UR::Context::commit() called as a function, not a method.  Assumming commit on current context' unless @_;
     }
-
-    $self->__signal_observers__('sync_databases', 1);
-
-    unless ($self->_commit_databases) {
-        $self->__signal_change__('commit',0);
-        die "Application failure during commit!";
-    }
-    $self->__signal_change__('commit',1);
-
-    foreach ( $self->all_objects_loaded('UR::Object') ) {
-        delete $_->{'_change_count'};
-    }
-
-    return 1;
+    $self = UR::Context->current();
+    $self->commit();
 }
 
 sub rollback {

--- a/lib/UR/Context/Process.pm
+++ b/lib/UR/Context/Process.pm
@@ -549,6 +549,8 @@ sub commit {
     }
     $self->__signal_change__('commit',1);
 
+    $_->delete foreach UR::Change->get();
+
     foreach ( $self->all_objects_loaded('UR::Object') ) {
         delete $_->{'_change_count'};
     }

--- a/lib/UR/Context/Process.pm
+++ b/lib/UR/Context/Process.pm
@@ -519,50 +519,6 @@ sub fork
 
 =over
 
-=item commit
-    $bool = UR::Context::Process->commit;
-
-Commits the top-level transaction by saving all object changes to the
-program's data sources.
-
-=back
-
-=cut
-
-sub commit {
-    my $self = shift;
-    ref($self) || Carp::croak('commit() must be called as an instance method, not a class method');
-
-    $self->__signal_change__('precommit');
-
-    unless ($self->_sync_databases) {
-        $self->__signal_observers__('sync_databases', 0);
-        $self->__signal_change__('commit',0);
-        return;
-    }
-
-    $self->__signal_observers__('sync_databases', 1);
-
-    unless ($self->_commit_databases) {
-        $self->__signal_change__('commit',0);
-        die "Application failure during commit!";
-    }
-    $self->__signal_change__('commit',1);
-
-    $_->delete foreach UR::Change->get();
-
-    foreach ( $self->all_objects_loaded('UR::Object') ) {
-        delete $_->{'_change_count'};
-    }
-
-    return 1;
-}
-
-
-=pod
-
-=over
-
 =item effective_user_name
 
   $login = UR::Context::Process->effective_user_name;

--- a/t/URT/t/99_transaction_log_all_changes.t
+++ b/t/URT/t/99_transaction_log_all_changes.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 
 use_ok('UR::Context::Transaction');
 
@@ -29,4 +29,37 @@ subtest 'ensure log_all_changes is turned off after last transaction' => sub {
     is($UR::Context::Transaction::log_all_changes, 1, 'rolling back inner transaction leaves log_all_changes enabled');
     pop(@tx)->rollback();
     is($UR::Context::Transaction::log_all_changes, 0, 'rolling back outer transaction disables log_all_changes');
+};
+
+subtest 'undos are fired by top-level context even if software tx commits' => sub {
+    plan tests => 1;
+
+    my $cb_was_called = 0;
+    my $cb = sub { $cb_was_called++ };
+
+    my $tx = UR::Context::Transaction->begin();
+    my $foo = UR::Value->get(1);
+    UR::Context::Transaction->log_change(
+        $foo, 'UR::Value', 1, 'external_change', $cb,
+    );
+
+    UR::Context->commit();      # $tx is the current transaction
+    UR::Context->rollback();    # this is the top-level transaction
+    is($cb_was_called, 1, 'external change was undone when top-level transaction was rolled back');
+};
+
+subtest 'undos are not fired after top-level tx commits' => sub {
+    plan tests => 1;
+
+    my $cb_was_called = 0;
+    my $shouldnt_be_called = sub { $cb_was_called++ };
+
+    my $foo = UR::Value->get(1);
+    UR::Context::Transaction->log_change(
+        $foo, 'UR::Value', 1, 'external_change', $shouldnt_be_called,
+    );
+
+    UR::Context->commit();      # Both of these are the top-level transaction
+    UR::Context->rollback();
+    is($cb_was_called, 0, 'external change was not undone in rollback');
 };

--- a/t/URT/t/99_transaction_log_all_changes.t
+++ b/t/URT/t/99_transaction_log_all_changes.t
@@ -43,7 +43,7 @@ subtest 'undos are fired by top-level context even if software tx commits' => su
         $foo, 'UR::Value', 1, 'external_change', $cb,
     );
 
-    UR::Context->commit();      # $tx is the current transaction
+    $tx->commit();      # $tx is the current transaction
     UR::Context->rollback();    # this is the top-level transaction
     is($cb_was_called, 1, 'external change was undone when top-level transaction was rolled back');
 };


### PR DESCRIPTION
Make sure Change objects are deleted after their scope ends to prevent them from being fired if a later transaction does a rollback().

This PR differs from #102 in that Change objects are not deleted when a software TX commits, only when the low-level Context transaction commits.