### PR TITLE
Fix sorter warning message

### DIFF
--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -620,7 +620,8 @@ sub sorter {
 
             my ($pmeta,@extra) = $class_meta->_concrete_property_meta_for_class_and_name($property);
             if(@extra) {
-                $pmeta = $class_meta->property($property); #a composite property (typically ID)
+                # maybe a composite property (typically ID), or a chained property (prop.other_prop)
+                $pmeta = $class_meta->property_meta_for_name($property);
             }
 
             if ($pmeta) {

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -590,9 +590,6 @@ sub id_property_sorter {
 }
 
 sub sorter {
-    #TODO: make this take +/- indications of ascending/descending
-    #TODO: make it into a closure for speed
-    #TODO: there are possibilities of it sorting different than a DB on mixed numbers and alpha data
     my ($self,@properties) = @_;
     push @properties, $self->id_property_names;
     my $key = join("__",@properties);

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -637,7 +637,7 @@ sub sorter {
             }
         }
 
-        no warnings;   # don't print a warning about undef values ...alow them to be treated as 0 or '' 
+        no warnings 'uninitialized';
         $sorter = $self->{_sorter}{$key} ||= sub($$) {
 
             for (my $n = 0; $n < @properties; $n++) {

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -608,20 +608,10 @@ sub sorter {
                 push @is_descending, 0;
             }
 
-            my $class_meta;
-            if ($self->isa("UR::Object::Set::Type")) {
-                # If we're a set, we want to examine the property of our members.
-                my $subject_class = $self->class_name;
-                $subject_class =~ s/::Set$//g;
-                $class_meta = $subject_class->__meta__;#->property($property);
-            } else {
-                $class_meta = $self;
-            }
-
-            my ($pmeta,@extra) = $class_meta->_concrete_property_meta_for_class_and_name($property);
+            my ($pmeta,@extra) = $self->_concrete_property_meta_for_class_and_name($property);
             if(@extra) {
                 # maybe a composite property (typically ID), or a chained property (prop.other_prop)
-                $pmeta = $class_meta->property_meta_for_name($property);
+                $pmeta = $self->property_meta_for_name($property);
             }
 
             if ($pmeta) {

--- a/t/URT/t/18_indirect_accessor.t
+++ b/t/URT/t/18_indirect_accessor.t
@@ -18,7 +18,8 @@ UR::Object::Type->define(
         id      => { type => "Number" },
         name    => { type => "String" },
         company => { type => "String" },
-    ]
+    ],
+    id_generator => sub { our $boss_seq; ++$boss_seq; },
 );
 
 UR::Object::Type->define(

--- a/t/URT/t/47c_is_many_accessor_with_id_class_by.t
+++ b/t/URT/t/47c_is_many_accessor_with_id_class_by.t
@@ -22,6 +22,7 @@ class URT::Note {
     has_optional => [
         body_text          => { is => 'Text', len => 1000 },
     ],
+    id_generator => sub { our $note_seq; ++$note_seq },
 };
 
 class URT::Notable {


### PR DESCRIPTION
Eliminates the warning message emitted by the object sorter commands when asked to show a chained property (propname.other_prop) about not being able to generate a sorter.

This was reported in (now closed) APIPE-3020, but it was a relatively easy fix, and found another bug when sorting Set objects (rather then their members)