### PR TITLE
Transaction validity

### DIFF
--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -415,6 +415,16 @@ objects.  As all activity to objects occurs in some kind of transaction
 context, the newly created transaction exists within whatever context was
 current before the call to begin().
 
+  $t = UR::Context::Transaction->begin(commit_validator => sub { ... });
+
+A validation function may be assigned with the C<commit_validator> property.
+When the transaction is committed, this function is called.  The commit
+proceeds if this function returns a true value.  The default function,
+C<changes_can_be_saved> requires that all objects changed within the
+transaction be valid, ie. that C<$obj->__errors__()> returns an empty list.
+The validation function is passed one argument: the transaction object
+being committed.
+
 =back
 
 =head1 METHODS
@@ -426,7 +436,16 @@ current before the call to begin().
   $t->commit();
 
 Causes all objects with changes to save those changes back to the underlying
-context.  
+context.
+
+If the validation function (specified with the C<commit_validator> param when
+the transaction was created with C<begin()>) returns false, the changes are
+not committed to the encompassing context, C<commit()> returns false and this
+transaction remains in effect.
+
+Returns true if all the transaction's changes are committed to the encompassing
+Context.  This transaction object then becomes invalid, and its state will be
+'committed'.
 
 =item rollback
 
@@ -436,6 +455,9 @@ Causes all objects with changes to have those changes reverted to their
 state when the transaction began.  Classes with properties whose meta-property
 is_transactional => 0 are not tracked within a transaction and will not be
 reverted.
+
+After C<rollback()>, this transaction becomes invalid, and the object will become
+a L<UR::DeletedRef>.
 
 =item delete
 

--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -316,11 +316,11 @@ sub eval_or_do {
         $class->debug_message(shortmess('Rolling back transaction'));
         $class->debug_message($eval_error) if ($eval_error);
         unless($tx->rollback()) {
-            die 'failed to rollback transaction';
+            Carp::croak 'failed to rollback transaction';
         }
     } else {
         unless($tx->commit()) {
-            die 'failed to commit transaction';
+            Carp::croak 'failed to commit transaction';
         }
     }
 

--- a/t/URT/t/99_transaction-failed_commit_rollback.t
+++ b/t/URT/t/99_transaction-failed_commit_rollback.t
@@ -53,10 +53,7 @@ subtest 'fail to commit then rollback' => sub {
     is(scalar(@messages), 2, 'commit generated 2 error messages');
     my $circleid = $circle->id;
     is($messages[0], 'Invalid data for save!', 'First error text is correct');
-    #like($msgobj[1]->text,
-    #     qr(Circle identified by $circleid has problem on\nINVALID: property 'test_property': intentional error for test)m,
-    #     'Error message text is correct');
-   like($messages[1],
+    like($messages[1],
         qr(Circle identified by $circleid has problems on\s+INVALID: property 'test_property': intentional error for test),
         'Error message text is correct');
 

--- a/t/URT/t/99_transaction-failed_commit_rollback.t
+++ b/t/URT/t/99_transaction-failed_commit_rollback.t
@@ -16,6 +16,14 @@ UR::Object::Type->define(
     ],
 );
 
+sub Circle::__errors__ {
+    my $tag = UR::Object::Tag->create (
+        type => 'invalid',
+        properties => ['test_property'],
+        desc => 'intentional error for test',
+    );
+    return ($tag);
+}
 
 # Create a Circle
 my $circle = Circle->create();
@@ -35,15 +43,6 @@ subtest 'fail to commit then rollback' => sub {
     $circle->radius($new_radius);
     is($circle->radius, $new_radius, "circle radius changed to new radius");
 
-    *Circle::__errors__ = sub {
-        my $tag = UR::Object::Tag->create (
-            type => 'invalid',
-            properties => ['test_property'],
-            desc => 'intentional error for test',
-        );
-        return ($tag);
-    };
-
     $transaction->dump_error_messages(0);
     $transaction->queue_error_messages(1);
 
@@ -60,6 +59,5 @@ subtest 'fail to commit then rollback' => sub {
     is($transaction->rollback, 1, 'rollback succeeded');
     is($circle->radius, $old_radius, 'circle radius was rolled back due to forced __errors__');
 };
-
 
 1;

--- a/t/URT/t/99_transaction-failed_commit_rollback.t
+++ b/t/URT/t/99_transaction-failed_commit_rollback.t
@@ -4,7 +4,7 @@ use warnings;
 use UR;
 use IO::File;
 
-use Test::More tests => 11;
+use Test::More tests => 3;
 
 UR::Object::Type->define(
     class_name => 'Circle',
@@ -23,7 +23,9 @@ ok($circle->isa('Circle'), 'create a circle');
 ok($circle->radius == 1, 'default radius is 1');
 
 
-{
+subtest 'fail to commit then rollback' => sub {
+    plan tests => 9;
+
     my $transaction = UR::Context::Transaction->begin;
     isa_ok($transaction, 'UR::Context::Transaction');
 
@@ -60,7 +62,7 @@ ok($circle->radius == 1, 'default radius is 1');
 
     is($transaction->rollback, 1, 'rollback succeeded');
     is($circle->radius, $old_radius, 'circle radius was rolled back due to forced __errors__');
-}
+};
 
 
 1;


### PR DESCRIPTION
The function used to validate objects when a software transaction is committed can be changed when the transaction is created.  The default behavior is to do what it's always done: verify that all changed objects are valid before committing.