### PR TITLE
Localize $@ in accessors

### DIFF
--- a/lib/UR/BoolExpr/Template/PropertyComparison.pm
+++ b/lib/UR/BoolExpr/Template/PropertyComparison.pm
@@ -131,9 +131,13 @@ sub comparison_value_and_escape_character_to_regex {
     # Wrap the regex in delimiters.
     $regex = "^${regex}\$";
 
-    $regex = eval { qr($regex) };
-    if ($@) {
-        Carp::confess($@);
+    my $exception = do {
+        local $@;
+        $regex = eval { qr($regex) };
+        $@;
+    };
+    if ($exception) {
+        Carp::confess($exception);
     }
 
     return $regex;

--- a/lib/UR/BoolExpr/Template/PropertyComparison/Isa.pm
+++ b/lib/UR/BoolExpr/Template/PropertyComparison/Isa.pm
@@ -14,6 +14,7 @@ sub _compare {
     
     if (ref $comparison_value) {
         # Reference... maybe an Object?
+        local $@;
         if (eval { $comparison_value->isa('UR::Object::Type')} ) {
             # It's a class object.  Compare to the Class's class_name
             $comparison_value = $comparison_value->class_name;


### PR DESCRIPTION
All the evals peppered through AccesorWriter clobber $@.

It tripped me up while testing that a method throws a certain exception.
The method correctly threw the exception, which ran a Scope::Guard object
which called a r/w object accessor, which clobbered $@.  The test then
failed to detect an exception had been thrown.

Rather than just fix the onle place that was causing this problem, I fixed
them all.