### PR TITLE
Method modifiers

### DIFF
--- a/lib/UR/Role.pm
+++ b/lib/UR/Role.pm
@@ -258,6 +258,79 @@ from.  The proper param value is returned.
 An exception is thrown if a class composes a role and either provides unknown
 role params or omits values for existing params.
 
+=head2 Method Modifiers
+
+Roles can hook into methods defined in consuming classes by using the "before",
+"after" and "around" method modifiers.
+
+  use UR;
+  package RoleWithModifiers;
+  use UR::Role qw(before after);
+  role RoleWithModifiers { };
+  before 'do_something' => sub {
+      my($self, @params) = @_;
+      print "Calling do_something with params ",join(',',@params),"\n";
+  };
+  after 'do_something' => sub {
+      my($rv, $self, @params) = @_;
+      print "Result from do_something: $rv\n";
+  };
+  around 'do_something' => sub {
+      my($orig, $self, @params) = @_;
+      print "Wrapped call to do_something params ",join(',',@params),"\n";
+      my $rv = $self->$orig(@params);
+      print "The wrapped call to do_something returned $rv\n";
+      return 123;
+  };
+
+  package ClassUsingRole;
+  class ClassUsingRole { roles => 'RoleWithModifiers' };
+  sub do_something {
+      print "In original do_something\n";
+      return 'abc';
+  }
+
+  my $rv = ClassUsingRole->create()->do_something();
+  print "The call to do_something returned $rv\n";
+
+Running this code will generate the following output:
+
+  Wrapped call to do_something params
+  Calling do_something with params
+  In original do_something
+  Result from do_something: abc
+  The wrapped call to do_something returned abc
+  The call to do_something returned 123
+
+Method modifiers are applied in the order they appear in the role's
+implementation.
+
+=over 4
+
+=item before(@params)
+
+A C<before> modifier runs before the named method. It receives all the
+arguments and C<wantarray> context as the original method call.  It cannot
+affect the parameters to the original method call, and its return value is
+ignored.
+
+=item after($rv, @params)
+
+The first argument to an C<after> modifier is the return value of the original
+method call, the remaining arguments and C<wantarray> context are the same as
+the original method call.  If the original method was called in list context,
+then C<$rv> will be an arrayref containing the list of return values.  This
+modifier's return value is ignored.
+
+=item around($orig, @params)
+
+An C<around> modifier is run in place of the original method, and receives
+a coderef of the original method as its first argument.  Around modifiers
+can munge arguments and return values, and control when and whether the
+original method is called.
+
+=back
+
 =head1 SEE ALSO
 
 L<UR>, L<UR::Object::Type::Initializer>, L<UR::Role::Instance>, L<UR::Role::Param>

--- a/lib/UR/Role/MethodModifier.pm
+++ b/lib/UR/Role/MethodModifier.pm
@@ -1,0 +1,68 @@
+package UR::Role::MethodModifier;
+use strict;
+use warnings;
+
+use Carp;
+use Sub::Install;
+
+my $idx = 1;
+UR::Object::Type->define(
+    class_name => 'UR::Role::MethodModifier',
+    is_abstract => 1,
+    id_by => [
+        idx => { is => 'Integer' },
+    ],
+    has => [
+        name => { is => 'String' },
+        code => { is => 'CODE' },
+        role_name => { is => 'String' },
+        role => { is => 'UR::Role::Prototype', id_by => 'role_name' },
+        type => { is => 'String' },
+    ],
+    id_generator => sub { $idx++ },
+);
+
+sub type {
+    my $class = ref(shift);
+    Carp::croak("Class $class didn't define sub type");
+}
+
+sub apply_to_package {
+    my($self, $package) = @_;
+
+    my $original_sub = $self->_get_original_sub($package);
+
+    unless ($original_sub) {
+        my $name = $self->name;
+        Carp::croak(qq(Cannot apply 'before' modifier to $name: Can't locate method "$name" via package $package));
+    }
+
+    my $wrapper = $self->create_wrapper_sub($original_sub);
+    my $fully_qualified_sub_name = join('::', $package, $self->name);
+
+    $self->_install_sub($package, $wrapper);
+}
+
+
+sub _get_original_sub {
+    my($self, $package) = @_;
+
+    my $fully_qualified_subname = join('::', $package, $self->name);
+
+    my $subref = do { no strict 'refs'; exists &$fully_qualified_subname and \&$fully_qualified_subname }
+                 || $package->super_can($self->name);
+
+    return $subref;
+}
+
+sub _install_sub {
+    my($self, $package, $code) = @_;
+    Sub::Install::reinstall_sub({
+        into => $package,
+        as => $self->name,
+        code => $code,
+    });
+}
+        
+
+1;

--- a/lib/UR/Role/MethodModifier/After.pm
+++ b/lib/UR/Role/MethodModifier/After.pm
@@ -1,0 +1,47 @@
+package UR::Role::MethodModifier::After;
+use strict;
+use warnings;
+
+use UR;
+
+UR::Object::Type->define(
+    class_name => 'UR::Role::MethodModifier::After',
+    is => 'UR::Role::MethodModifier',
+);
+
+sub type { 'after' }
+
+sub create_wrapper_sub {
+    my($self, $original_sub) = @_;
+
+    my $after = $self->code;
+    return sub {
+        my @rv;
+        my $wantarray = wantarray;
+        if ($wantarray) {
+            @rv = $original_sub->(@_);
+        } elsif (defined $wantarray) {
+            $rv[0] = $original_sub->(@_);
+        } else {
+            $original_sub->(@_);
+        }
+
+        if ($wantarray) {
+            () = $after->(\@rv, @_);
+        } elsif (defined $wantarray) {
+            my $i = $after->($rv[0], @_);
+        } else {
+            $after->(undef, @_);
+        }
+
+        if ($wantarray) {
+            return @rv;
+        } elsif (defined $wantarray) {
+            return $rv[0];
+        } else {
+            return;
+        }
+    };
+}
+
+1;

--- a/lib/UR/Role/MethodModifier/Around.pm
+++ b/lib/UR/Role/MethodModifier/Around.pm
@@ -1,0 +1,23 @@
+package UR::Role::MethodModifier::Around;
+use strict;
+use warnings;
+
+use UR;
+
+UR::Object::Type->define(
+    class_name => 'UR::Role::MethodModifier::Around',
+    is => 'UR::Role::MethodModifier',
+);
+
+sub type { 'around' }
+
+sub create_wrapper_sub {
+    my($self, $original_sub) = @_;
+
+    my $around = $self->code;
+    return sub {
+        $around->($original_sub, @_);
+    };
+}
+
+1;

--- a/lib/UR/Role/MethodModifier/Before.pm
+++ b/lib/UR/Role/MethodModifier/Before.pm
@@ -1,0 +1,30 @@
+package UR::Role::MethodModifier::Before;
+use strict;
+use warnings;
+
+use UR;
+
+UR::Object::Type->define(
+    class_name => 'UR::Role::MethodModifier::Before',
+    is => 'UR::Role::MethodModifier',
+);
+
+sub type { 'before' }
+
+sub create_wrapper_sub {
+    my($self, $original_sub) = @_;
+
+    my $before = $self->code;
+    return sub {
+        if (wantarray) {
+            () = $before->(@_);
+        } elsif (defined wantarray) {
+            my $rv = $before->(@_);
+        } else {
+            $before->(@_);
+        }
+        $original_sub->(@_);
+    };
+}
+
+1;

--- a/lib/UR/Role/Prototype.pm
+++ b/lib/UR/Role/Prototype.pm
@@ -178,7 +178,7 @@ sub _get_property_desc_from_ur_object_type {
     }
 }
 
-my @DONT_EXPORT_THESE_SUBS_TO_CLASSES = qw(__import__ FETCH_CODE_ATTRIBUTES MODIFY_CODE_ATTRIBUTES MODIFY_SCALAR_ATTRIBUTES);
+my @DONT_EXPORT_THESE_SUBS_TO_CLASSES = qw(__import__ FETCH_CODE_ATTRIBUTES MODIFY_CODE_ATTRIBUTES MODIFY_SCALAR_ATTRIBUTES before after around);
 sub _introspect_methods {
     my $role_name = shift;
 

--- a/lib/UR/Role/PrototypeWithParams.pm
+++ b/lib/UR/Role/PrototypeWithParams.pm
@@ -52,7 +52,7 @@ foreach my $accessor_name ( qw( prototype role_params ) ) {
 # accessors that delegate to the role prototype
 foreach my $accessor_name ( qw( role_name methods overloads has requires attributes_have excludes
                                 property_names property_data method_names
-                                meta_properties_to_compose_into_classes ),
+                                meta_properties_to_compose_into_classes method_modifiers ),
                             UR::Role::Prototype::meta_properties_to_compose_into_classes()
 ) {
     my $sub = sub {


### PR DESCRIPTION
Adds new method modifier functionality to UR roles.

You can add hooks that run before, after or around a method in the consuming class.

The Genome roles branch needs ```around``` so Genome::Sample can properly be an ObjectWithLockedConstruction, and inherit Genome::Subject's ```create()```.