### PR TITLE
Id-by in roles

### DIFF
--- a/lib/UR/Role.pm
+++ b/lib/UR/Role.pm
@@ -274,7 +274,7 @@ Roles can hook into methods defined in consuming classes by using the "before",
 
   use UR;
   package RoleWithModifiers;
-  use UR::Role qw(before after);
+  use UR::Role qw(before after around);
   role RoleWithModifiers { };
   before 'do_something' => sub {
       my($self, @params) = @_;

--- a/lib/UR/Role.pm
+++ b/lib/UR/Role.pm
@@ -92,6 +92,9 @@ UR::Role - Roles in UR, an alternative to inheritance
 
   package My::Role;
   role My::Role {
+      id_by => [
+          role_id_property => { is => 'String' },
+      ],
       has => [
           role_property => { is => 'String' },
           another_prop  => { is => 'Integer' },
@@ -172,6 +175,12 @@ the class.
 An exception is thrown if multiple Roles are composed together that define
 the same property, even if the composing class defines the same property in
 an attempt to override them.
+
+A class may declare a property with the same name that a role also declares.
+The definition in the class overrides whatever appears in the role.  An
+exception is thrown if a role declares an ID property in the 'id_by' section
+and the consuming class redeclares it in the 'has' section as a normal
+property.
 
 =head3 Method conflicts
 

--- a/lib/UR/Role/Prototype.pm
+++ b/lib/UR/Role/Prototype.pm
@@ -46,7 +46,7 @@ sub property_data {
     return $self->has->{$property_name};
 }
 
-sub property_names {
+sub has_property_names {
     my $self = shift;
     return keys %{ $self->has };
 }
@@ -320,7 +320,7 @@ sub _collect_properties_from_roles {
 
     my(%properties_to_add, %source_for_properties_to_add);
     foreach my $role ( @role_objs ) {
-        my @role_property_names = $role->property_names;
+        my @role_property_names = $role->has_property_names;
         foreach my $property_name ( @role_property_names ) {
             my $prop_definition = $role->property_data($property_name);
             if (my $conflict = $source_for_properties_to_add{$property_name}) {
@@ -462,7 +462,7 @@ sub _validate_role_requirements {
         }
 
         # Properties and methods from this role can satisfy requirements for later roles
-        foreach my $name ( $role->property_names, $role->method_names ) {
+        foreach my $name ( $role->has_property_names, $role->method_names ) {
             $found_properties_and_methods{$name} = 1;
         }
     }
@@ -717,9 +717,9 @@ same properties as L<UR::Object::Type> instances.
 
 Returns a hashref of property data about the named property.
 
-=item property_names()
+=item has_property_names()
 
-Returns a list of all the properties in the role's C<has>.
+Returns a list of all the properties named in the role's C<has>.
 
 =item method_names()
 

--- a/lib/UR/Role/Prototype.pm
+++ b/lib/UR/Role/Prototype.pm
@@ -21,6 +21,7 @@ UR::Object::Type->define(
     doc => 'Object representing a role',
     id_by => 'role_name',
     has => [
+        id_by       => { is => 'ARRAY', doc => 'List of ID properties and their definitions' },
         role_name   => { is => 'Text', doc => 'Package name identifying the role' },
         class_names => { is => 'Text', is_many => 1, doc => 'Class names composing this role' },
         methods     => { is => 'HASH', doc => 'Map of method names and coderefs', default => {} },
@@ -49,6 +50,11 @@ sub property_data {
 sub has_property_names {
     my $self = shift;
     return keys %{ $self->has };
+}
+
+sub id_by_property_names {
+    my $self = shift;
+    return @{ $self->id_by };
 }
 
 sub method_names {
@@ -720,6 +726,10 @@ Returns a hashref of property data about the named property.
 =item has_property_names()
 
 Returns a list of all the properties named in the role's C<has>.
+
+=item id_by_property_names()
+
+Returns a list of all the properties named in the roles's C<id_by>.
 
 =item method_names()
 

--- a/lib/UR/Role/PrototypeWithParams.pm
+++ b/lib/UR/Role/PrototypeWithParams.pm
@@ -51,7 +51,7 @@ foreach my $accessor_name ( qw( prototype role_params ) ) {
 
 # accessors that delegate to the role prototype
 foreach my $accessor_name ( qw( role_name methods overloads has requires attributes_have excludes
-                                property_names property_data method_names
+                                has_property_names property_data method_names
                                 meta_properties_to_compose_into_classes method_modifiers ),
                             UR::Role::Prototype::meta_properties_to_compose_into_classes()
 ) {

--- a/lib/UR/Role/PrototypeWithParams.pm
+++ b/lib/UR/Role/PrototypeWithParams.pm
@@ -51,7 +51,7 @@ foreach my $accessor_name ( qw( prototype role_params ) ) {
 
 # accessors that delegate to the role prototype
 foreach my $accessor_name ( qw( role_name methods overloads has requires attributes_have excludes
-                                has_property_names property_data method_names
+                                id_by_property_names has_property_names property_data method_names
                                 meta_properties_to_compose_into_classes method_modifiers ),
                             UR::Role::Prototype::meta_properties_to_compose_into_classes()
 ) {

--- a/t/URT/t/9_role.t
+++ b/t/URT/t/9_role.t
@@ -193,7 +193,7 @@ subtest requires => sub {
 };
 
 subtest 'conflict property' => sub {
-    plan tests => 8;
+    plan tests => 9;
 
     role URT::ConflictPropertyRole1 {
         has => [
@@ -261,6 +261,20 @@ subtest 'conflict property' => sub {
     $prop_meta = URT::ConflictPropertyClassWithIdProperty->__meta__->property('conflict_property');
     is($prop_meta->data_type, 'ClassProperty', 'Class gets the class-defined property');
     ok($prop_meta->is_id, 'property is an id-by property');
+
+    role URT::ConflictProperty::RoleWithIdProperty {
+        id_by => 'role_id_property',
+    };
+    throws_ok
+        {
+            class URT::ConflictProperty::ClassRedefinesIdPropertyAsNonId {
+                has => ['role_id_property'],
+                roles => ['URT::ConflictProperty::RoleWithIdProperty'],
+            }
+        }
+        qr(Cannot compose role URT::ConflictProperty::RoleWithIdProperty: Property 'role_id_property' was declared as a normal property in class URT::ConflictProperty::ClassRedefinesIdPropertyAsNonId, but as an ID property in the role),
+        'Composing role with ID property into class as non-ID property fails';
+
 };
 
 subtest 'conflict methods' => sub {

--- a/t/URT/t/9_role.t
+++ b/t/URT/t/9_role.t
@@ -10,12 +10,17 @@ use URT;
 use UR::Role;
 
 subtest basic => sub {
-    plan tests => 18;
+    plan tests => 28;
 
+    my $id_gen = 1;
     role URT::BasicRole {
+        id_by => [
+            role_id_property => { is => 'Integer' },
+        ],
         has => [
             role_property => { is => 'String' },
         ],
+        id_generator => sub { ++$id_gen },
         requires => [ 'required_property', 'required_method' ],
         excludes => [ ],
     };
@@ -44,10 +49,29 @@ subtest basic => sub {
     is($role_instances->[0]->class_name, 'URT::BasicClass', 'Role instance class_name');
     is($role_instance->class_meta, $class_meta, 'Role instance class_meta');
 
+    my @all_class_property_names = qw(role_id_property role_property regular_property required_property);
+    my %property_is_id = (role_id_property => '0 but true', role_property => undef, regular_property => undef, required_property => undef );
+    foreach my $prop_name ( @all_class_property_names ) {
+        my $prop_meta = $class_meta->property($prop_name);
+        is($prop_meta->is_id, $property_is_id{$prop_name}, "property $prop_name is_id value");
+    }
+
+    my %property_source = ( role_id_property => 'URT::BasicRole', role_property => 'URT::BasicRole',
+                            regular_property => 'URT::BasicClass', required_property => 'URT::BasicClass' );
+    foreach my $prop_name ( @all_class_property_names ) {
+        my $expected_source = $property_source{$prop_name};
+        my $prop_meta = $class_meta->property($prop_name);
+        like($prop_meta->is_specified_in_module_header,
+             qr/^$expected_source/,
+             "property $prop_name is_specified_in_module_header");
+    }
+
     my $o = URT::BasicClass->create(required_property => 1, role_property => 1, regular_property => 1);
-    foreach my $method ( qw( required_property role_property regular_property role_method required_method ) ) {
+    foreach my $method ( qw( role_id_property required_property role_property regular_property role_method required_method ) ) {
         ok($o->$method, "call $method");
     }
+
+    is($o->id, $id_gen, 'id_generator was called to generate an ID');
 
     throws_ok
         {
@@ -169,7 +193,7 @@ subtest requires => sub {
 };
 
 subtest 'conflict property' => sub {
-    plan tests => 5;
+    plan tests => 8;
 
     role URT::ConflictPropertyRole1 {
         has => [
@@ -225,6 +249,18 @@ subtest 'conflict property' => sub {
         'Composed role into class sharing property name';
     my $prop_meta = URT::ConflictPropertyClassWithProperty->__meta__->property('conflict_property');
     is($prop_meta->data_type, 'ClassProperty', 'Class gets the class-defined property');
+
+    lives_ok
+        {
+            class URT::ConflictPropertyClassWithIdProperty {
+                id_by => [ conflict_property => { is => 'ClassProperty' } ],
+                roles => ['URT::ConflictPropertyRole1'],
+            }
+        }
+        'Composed role into class sharing id-by property name';
+    $prop_meta = URT::ConflictPropertyClassWithIdProperty->__meta__->property('conflict_property');
+    is($prop_meta->data_type, 'ClassProperty', 'Class gets the class-defined property');
+    ok($prop_meta->is_id, 'property is an id-by property');
 };
 
 subtest 'conflict methods' => sub {


### PR DESCRIPTION
Allows roles to have id_by properties that get applied to classes.

One restriction is that if a role declares a property as id_by, and a consuming class declares the same property as non-id-by, it throws an exception.  It's not an exception for a role to declare a normal property and a consuming class to upgrade it to id_by.