### PR TITLE
Default datasource counts as a table

### DIFF
--- a/lib/UR/DataSource.pm
+++ b/lib/UR/DataSource.pm
@@ -511,7 +511,7 @@ sub _first_class_in_inheritance_with_a_table {
     my $found = "";
     for ($class_object, $class_object->ancestry_class_metas)
     {                
-        if ($_->table_name)
+        if ($_->has_direct_table)
         {
             $found = $_->class_name;
             last;

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -896,9 +896,20 @@ sub has_table {
     for my $class_name (@parent_classes) {
         next if $class_name eq "UR::Object";
         my $class_obj = UR::Object::Type->get(class_name => $class_name);
-        if ($class_obj->table_name) {
+        if ($class_obj->has_direct_table) {
             return 1;
         }
+    }
+    return;
+}
+
+sub has_direct_table {
+    my $self = shift;
+    return 1 if $self->table_name;
+
+    if ($self->data_source_id and $self->data_source_id->isa('UR::DataSource::Default')) {
+        my $load_function_name = join('::', $self->class_name, '__load__');
+        return 1 if exists &$load_function_name;
     }
     return;
 }

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -921,7 +921,7 @@ sub most_specific_subclass_with_table {
 
     foreach my $class_name ( $self->class_name->inheritance ) {
         my $class_obj = UR::Object::Type->get(class_name => $class_name);
-        return $class_name if ($class_obj && $class_obj->table_name);
+        return 1 if ($class_obj and $class_obj->has_direct_table);
     }
     return;
 }
@@ -932,7 +932,7 @@ sub most_general_subclass_with_table {
     my @subclass_list = reverse ( $self->class_name, $self->class_name->inheritance );
     foreach my $class_name ( $self->inheritance ) {
         my $class_obj = UR::Object::Type->get(class_name => $class_name);
-        return $class_name if ($class_obj && $class_obj->table_name);
+        return $class_name if ($class_obj && $class_obj->has_direct_table);
     }
     return;
 }

--- a/lib/UR/Object/Type/InternalAPI.pm
+++ b/lib/UR/Object/Type/InternalAPI.pm
@@ -921,7 +921,7 @@ sub most_specific_subclass_with_table {
 
     foreach my $class_name ( $self->class_name->inheritance ) {
         my $class_obj = UR::Object::Type->get(class_name => $class_name);
-        return 1 if ($class_obj and $class_obj->has_direct_table);
+        return $class_name if ($class_obj and $class_obj->has_direct_table);
     }
     return;
 }


### PR DESCRIPTION
Classes using the Default data source weren't able to use automagic subclassing (subclassify_by) because the loading system wasn't able to determine the class' source of data; it was expecting to see one of the classes in its ancestry have a table_name.

This makes it recognize that having the Default data source and a ```__load__()``` method count as a source of data.