### PR TITLE
Detect role override error

### DIFF
--- a/lib/UR/AttributeHandlers.pm
+++ b/lib/UR/AttributeHandlers.pm
@@ -73,14 +73,14 @@ sub modify_attributes {
     return @not_recognized;
 }
 
-my %stored_attributes;
+my %stored_attributes_by_ref;
 
 sub fetch_attributes {
     my($package, $ref) = @_;
 
     my $reftype = attributes::reftype($ref);
     my @attrs;
-    foreach my $attr ( keys %{ $stored_attributes{$ref} } ) {
+    foreach my $attr ( keys %{ $stored_attributes_by_ref{$ref} } ) {
         if (my $handler = _fetch_attribute_handler($ref, $attr)) {
             push @attrs, $handler->($package, $ref);
         }
@@ -91,7 +91,7 @@ sub fetch_attributes {
 sub modify_code_overrides {
     my($package, $coderef, $attr, @params) = @_;
 
-    my $list = $stored_attributes{$coderef}->{overrides} ||= [];
+    my $list = $stored_attributes_by_ref{$coderef}->{overrides} ||= [];
     push @$list, @params;
 }
 
@@ -108,13 +108,13 @@ sub fetch_code_overrides {
     my($package, $coderef) = @_;
 
     return sprintf('overrides(%s)',
-                    join(', ', @{ $stored_attributes{$coderef}->{overrides} }));
+                    join(', ', @{ $stored_attributes_by_ref{$coderef}->{overrides} }));
 }
 
 sub get_overrides_for_coderef {
     my($ref) = @_;
-    return( exists($stored_attributes{$ref}) && exists($stored_attributes{$ref}->{overrides})
-                ? @{ $stored_attributes{$ref}->{overrides} }
+    return( exists($stored_attributes_by_ref{$ref}) && exists($stored_attributes_by_ref{$ref}->{overrides})
+                ? @{ $stored_attributes_by_ref{$ref}->{overrides} }
                 : ()
             );
 }

--- a/lib/UR/Role/Prototype.pm
+++ b/lib/UR/Role/Prototype.pm
@@ -564,7 +564,7 @@ sub _validate_class_desc_overrides {
                         . "Did you forget to add the 'Overrides' attribute?");
         }
 
-        my @missing_methods = grep { ! $role_name->can($_) }
+        my @missing_methods = grep { ! exists $this_role_methods->{$_} and ! exists $role->has->{$_} }
                               @{$overridden_methods_by_role{$role_name}};
         if (@missing_methods) {
             my $plural = scalar(@missing_methods) > 1 ? 's' : '';

--- a/lib/UR/Role/Prototype.pm
+++ b/lib/UR/Role/Prototype.pm
@@ -220,6 +220,7 @@ sub _apply_roles_to_class_desc {
         Carp::croak('_apply_roles_to_class_desc() must be called as a class method on a basic class description');
     }
 
+    _validate_class_method_overrides_consumed_roles($desc);
     return unless ($desc->{roles} and @{ $desc->{roles} });
     my @role_objs = _role_prototypes_with_params_for_class_desc($desc);
 
@@ -487,6 +488,29 @@ sub _validate_role_exclusions {
                                 $desc->{class_name},
                                 $role->role_name,
                                 $plural ? 'them' : 'it'));
+        }
+    }
+    return 1;
+}
+
+sub _validate_class_method_overrides_consumed_roles {
+    my $desc = shift;
+
+    my $class_name = $desc->{class_name};
+    my %this_class_role_names = $desc->{roles}
+                                ? map { ref($_) ? ($_->role_name => 1) : ($_ => 1) }
+                                    @{$desc->{roles}}
+                                : ();
+    my $this_class_methods = UR::Util::coderefs_for_package($class_name);
+    while (my($method_name, $subref) = each %$this_class_methods) {
+        my @overrides = UR::AttributeHandlers::get_overrides_for_coderef($subref);
+        next unless (@overrides);
+
+        my @missing_role_names = grep { ! exists $this_class_role_names{$_} }
+                                 @overrides;
+        if (@missing_role_names) {
+            Carp::croak("Class method '$method_name' declares Overrides for roles the class does not consume: "
+                        . join(', ', @missing_role_names));
         }
     }
     return 1;

--- a/t/URT/t/9_role.t
+++ b/t/URT/t/9_role.t
@@ -271,7 +271,7 @@ subtest 'conflict methods' => sub {
 };
 
 subtest 'conflict methods with overrides' => sub {
-    plan tests => 7;
+    plan tests => 8;
 
     sub URT::ConflictMethodOverrideRole1::conflict_method { 0; }
     role URT::ConflictMethodOverrideRole1 { };
@@ -350,6 +350,16 @@ subtest 'conflict methods with overrides' => sub {
         }
         qr(Cannot compose role URT::ConflictMethodOverrideRole1: Class method 'bogus' declares it Overrides non-existant method in the role),
         'Overriding a non-existant method throws an exception';
+
+    throws_ok
+        {
+            package URT::ClassDeclaresOverrideForNonConsumedRole;
+            use URT;
+            sub bogus : Overrides(URT::ClassDeclaresOverride__RoleDoesNotExist) { }
+            class URT::ClassDeclaresOverrideForNonConsumedRole { };
+        }
+        qr(Class method 'bogus' declares Overrides for roles the class does not consume: URT::ClassDeclaresOverride__RoleDoesNotExist),
+        'Class Overriding a role it does not consume throws an exception';
 };
 
 subtest 'dynamic loading' => sub {

--- a/t/URT/t/9_role.t
+++ b/t/URT/t/9_role.t
@@ -271,7 +271,7 @@ subtest 'conflict methods' => sub {
 };
 
 subtest 'conflict methods with overrides' => sub {
-    plan tests => 6;
+    plan tests => 7;
 
     sub URT::ConflictMethodOverrideRole1::conflict_method { 0; }
     role URT::ConflictMethodOverrideRole1 { };
@@ -338,6 +338,18 @@ subtest 'conflict methods with overrides' => sub {
             }
         }
         'Class declared override even though parent did not';
+
+    throws_ok
+        {
+            package URT::ClassDeclaresOverrideForNonExistantMethod;
+            use URT;
+            sub bogus : Overrides(URT::ConflictMethodOverrideRole1) { }
+            class URT::ClassDeclaresOverrideForNonExistantMethod {
+                roles => ['URT::ConflictMethodOverrideRole1'],
+            };
+        }
+        qr(Cannot compose role URT::ConflictMethodOverrideRole1: Class method 'bogus' declares it Overrides non-existant method in the role),
+        'Overriding a non-existant method throws an exception';
 };
 
 subtest 'dynamic loading' => sub {

--- a/t/URT/t/9_role.t
+++ b/t/URT/t/9_role.t
@@ -271,7 +271,7 @@ subtest 'conflict methods' => sub {
 };
 
 subtest 'conflict methods with overrides' => sub {
-    plan tests => 8;
+    plan tests => 9;
 
     sub URT::ConflictMethodOverrideRole1::conflict_method { 0; }
     role URT::ConflictMethodOverrideRole1 { };
@@ -338,6 +338,21 @@ subtest 'conflict methods with overrides' => sub {
             }
         }
         'Class declared override even though parent did not';
+
+
+    role URT::RoleWithPropertyOverriddenInClass {
+        has => ['a_property'],
+    };
+    lives_ok
+        {
+            package URT::ClassUsesRoleAndOverridesPropertyWithMethod;
+            use URT;
+            sub a_property : Overrides(URT::RoleWithPropertyOverriddenInClass) { }
+            class URT::ClassUsesRoleAndOverridesPropertyWithMethod {
+                roles => ['URT::RoleWithPropertyOverriddenInClass'],
+            }
+        }
+       'Class can declare method to override a role property';
 
     throws_ok
         {


### PR DESCRIPTION
Additional checks for subroutines having the ```Overrides``` attribute
* The role named in the override must have a function or property of the same name
* The role named in the override must be consumed by the class