### PR TITLE
Indicate that Role Instances are not transactional.

### DIFF
--- a/lib/UR/Role/Instance.pm
+++ b/lib/UR/Role/Instance.pm
@@ -16,6 +16,7 @@ UR::Object::Type->define(
         class_meta => { is => 'UR::Object::Type', id_by => 'class_name' },
         role_params => { is => 'HASH', doc => 'Parameters used when this role was composed', is_optional => 1 },
     ],
+    is_transactional => 0,
 );
 
 1;


### PR DESCRIPTION
This fixes an error we've been seeing in model tests in Genome:

```
Attempt to use a reference to an object which has been deleted.  A call was made to method 'role_name'
Ressurrect it first.
$VAR1 = bless( {
                  'original_class' => 'UR::Role::Instance',
                  'original_data' => {
                                      'class_name' => 'Genome::Sys::User',
                                       '_change_count' => 2,
                                       '__get_serial' => 1211,
                                       'role_params' => {},
                                       'role_name' => 'Genome::Role::SoftwareResultSponsor',
                                       'id' => 'Genome::Role::SoftwareResultSponsor Genome::Sys::User'
                                     }
                }, 'UR::DeletedRef' );
```