### PR TITLE
Iterator enhancements

### DIFF
--- a/lib/UR/Iterator.pm
+++ b/lib/UR/Iterator.pm
@@ -1,0 +1,166 @@
+package UR::Iterator;
+
+use strict;
+use warnings;
+
+our $VERSION = "0.44"; # UR $VERSION;
+
+our @CARP_NOT = qw( UR::Object );
+
+# These are not UR Objects.  They're regular blessed references that
+# get garbage collected in the regular ways
+
+sub create {
+    my $class = shift;
+    Carp::croak("$class objects cannot be created via create().  Please see the documentation for more details");
+}
+
+sub create_for_list {
+    my $class = shift;
+    my $items = \@_;
+
+    foreach my $item ( @$items ) {
+        unless (defined $item) {
+            Carp::croak('undefined items are not allowed in an iterator list');
+        }
+    }
+
+    my $code = sub {
+        shift @$items;
+    };
+    my $self = bless { _iteration_closure => $code }, __PACKAGE__;
+    return $self;
+}
+
+sub map($&) {
+    my($self, $mapper) = @_;
+
+    my $wrapper = sub {
+        local $_ = $self->next;
+        defined($_) ? $mapper->() : $_;
+    };
+
+    return bless { _iteration_closure => $wrapper }, __PACKAGE__;
+}
+
+sub _iteration_closure {
+    my $self = shift;
+    if (@_) {
+        return $self->{_iteration_closure} = shift;
+    }
+    $self->{_iteration_closure};
+}
+
+
+sub peek {
+    my $self = shift;
+    unless (exists $self->{peek_value}) {
+        $self->{peek_value} = $self->{_iteration_closure}->();
+    }
+    $self->{peek_value};
+}
+
+
+sub next {
+    my $self = shift;
+    if (exists $self->{peek_value}) {
+        delete $self->{peek_value};
+    } else {
+        $self->{_iteration_closure}->(@_);
+    }
+}
+
+sub remaining {
+    my $self = shift;
+    my @remaining;
+    while (defined(my $o = $self->next )) {
+        push @remaining, $o;
+    }
+    @remaining;
+}
+
+1;
+
+=pod
+
+=head1 NAME
+
+UR::Iterator - API for iterating through data
+
+=head1 SYNOPSIS
+
+  my $iter = UR::Iterator->create_for_list(1, 2, 3, 4);
+  while (my $i = $iter->next) {
+    print $i\n";
+  }
+
+  my $mapped_iter = $iter->map(sub { $_ + 1 });
+  while (my $i = $mapped_iter->next) {
+    print "$i\n";
+  }
+
+=head1 DESCRIPTION
+
+UR::Iterator instances implement the iterator pattern.  These objects can
+be created with either a list of values, or by applying a mapping function
+to another iterator.
+
+UR::Iterator instances are normal Perl object references, not UR-based
+objects.  They do not live in the Context's object cache, and obey the
+normal Perl rules about scoping.
+
+=head1 METHODS
+
+=over 4
+
+=item create_for_list
+
+  $iter = UR::Object::Iterator->create_for_list(@values);
+
+Creates an iterator based on values contained in the given list.  This
+constructor will throw an exception if any of the supplied values is
+C<undef>.
+
+=item map
+
+  $new_iter = $iter->map(sub { $_ + 1 });
+
+Creates a new iterator based on an existing iterator.  Values returned by this
+new iterator are based on the values of the existing iterator after going
+through a mapping function.  This new iterator will  be exhausted when the
+original iterator is exhausted.
+
+When the mapping function is called, C<$_> is set to the value obtained from
+the original iterator.
+
+=item next
+
+  $obj = $iter->next();
+
+Return the next object matching the iterator's rule.  When there are no more
+matching objects, it returns undef.
+
+=item peek
+
+  $obj = $iter->peek();
+
+Return the next object matching the iterator's rule without removing it.  The
+next call to peek() or next() will return the same object.  Returns undef if
+there are no more matching objects.
+
+This is useful to test whether a newly created iterator matched anything.
+
+=item remaining
+
+  @objs = $iter->remaining();
+
+Return a list of all the objects remaining in the iterator.  The list will be
+empty if there is no more data.
+
+=back
+
+=head1 SEE ALSO
+
+L<UR::Object::Iterator>
+
+=cut

--- a/lib/UR/Object/Iterator.pm
+++ b/lib/UR/Object/Iterator.pm
@@ -38,6 +38,18 @@ sub create_for_list {
     return $self;
 }
 
+sub map($&) {
+    my($self, $mapper) = @_;
+
+    my $wrapper = sub {
+        local $_ = $self->next;
+        defined($_) ? $mapper->() : $_;
+    };
+
+    return bless { _iteration_closure => $wrapper }, ref($self);
+}
+
+
 sub _iteration_closure {
     my $self = shift;
     if (@_) {
@@ -127,6 +139,15 @@ with the $return_closure flag set to true.
   $iter = UR::Object::Iterator->create_for_listref( [ $obj1, $obj2, ... ] );
 
 Creates an iterator based on objects contained in the given listref.
+
+=item map
+
+  $new_iter = $iter->map(sub { $_ + 1 });
+
+Creates a new iterator based on an existing iterator.  Values returned by this
+new iterator are based on the values of the existing iterator after going
+through a mapping function.  This new iterator will  be exhausted when the
+original iterator is exhausted.
 
 =item next
 

--- a/lib/UR/Object/Iterator.pm
+++ b/lib/UR/Object/Iterator.pm
@@ -10,29 +10,6 @@ our @CARP_NOT = qw( UR::Object );
 # These are no longer UR Objects.  They're regular blessed references that
 # get garbage collected in the regular ways
 
-#use UR;
-#
-#UR::Object::Type->define(
-#    class_name      => __PACKAGE__,
-#    has => [
-#        filter_rule_id          => {},
-#    ],
-#);
-#
-#sub create_for_filter_rule {
-#    my $class = shift;
-#    my $filter_rule = shift;
-#    my $code = $UR::Context::current->get_objects_for_class_and_rule($filter_rule->subject_class_name,$filter_rule,undef,1);
-#    
-#    my $self = $class->SUPER::create(
-#        # TODO: some bug with frozen items?
-#        filter_rule_id      => $filter_rule->id,        
-#    );
-#    
-#    $self->_iteration_closure($code);    
-#    return $self;
-#}
-
 sub create {
     die "Don't call UR::Object::Iterator->create(), use create_for_filter_rule() instead";
 }

--- a/lib/UR/Object/Iterator.pm
+++ b/lib/UR/Object/Iterator.pm
@@ -60,8 +60,22 @@ sub _iteration_closure {
 }
 
 
+sub peek {
+    my $self = shift;
+    unless (exists $self->{peek_value}) {
+        $self->{peek_value} = $self->{_iteration_closure}->();
+    }
+    $self->{peek_value};
+}
+
+
 sub next {
-    shift->{_iteration_closure}->(@_);
+    my $self = shift;
+    if (exists $self->{peek_value}) {
+        delete $self->{peek_value};
+    } else {
+        $self->{_iteration_closure}->(@_);
+    }
 }
 
 
@@ -119,6 +133,16 @@ with the $return_closure flag set to true.
 
 Return the next object matching the iterator's rule.  When there are no more
 matching objects, it returns undef.
+
+=item peek
+
+  $obj = $iter->peek();
+
+Return the next object matching the iterator's rule without removing it.  The
+next call to peek() or next() will return the same object.  Returns undef if
+there are no more matching objects.
+
+This is useful to test whether a newly created iterator matched anything.
 
 =back
 

--- a/lib/UR/Object/Iterator.pm
+++ b/lib/UR/Object/Iterator.pm
@@ -55,6 +55,14 @@ sub next {
     }
 }
 
+sub remaining {
+    my $self = shift;
+    my @remaining;
+    while (my $o = $self->next ) {
+        push @remaining, $o;
+    }
+    @remaining;
+}
 
 1;
 
@@ -120,6 +128,13 @@ next call to peek() or next() will return the same object.  Returns undef if
 there are no more matching objects.
 
 This is useful to test whether a newly created iterator matched anything.
+
+=item remaining
+
+  @objs = $iter->remaining();
+
+Return a list of all the objects remaining in the iterator.  The list will be
+empty if there are no more matching objects.
 
 =back
 

--- a/lib/UR/Object/Iterator.pm
+++ b/lib/UR/Object/Iterator.pm
@@ -27,6 +27,16 @@ sub create_for_filter_rule {
     return $self;
 }
 
+sub create_for_list {
+    my $class = shift;
+    my $items = \@_;
+
+    my $code = sub {
+        shift @$items;
+    };
+    my $self = bless { _iteration_closure => $code }, $class;
+    return $self;
+}
 
 sub _iteration_closure {
     my $self = shift;
@@ -58,7 +68,7 @@ sub next {
 sub remaining {
     my $self = shift;
     my @remaining;
-    while (my $o = $self->next ) {
+    while (defined(my $o = $self->next )) {
         push @remaining, $o;
     }
     @remaining;
@@ -111,6 +121,12 @@ obey the normal Perl rules about scoping.
 Creates an iterator object based on the given BoolExpr (rule).  Under the
 hood, it calls get_objects_for_class_and_rule() on the current Context
 with the $return_closure flag set to true.
+
+=item create_for_listref
+
+  $iter = UR::Object::Iterator->create_for_listref( [ $obj1, $obj2, ... ] );
+
+Creates an iterator based on objects contained in the given listref.
 
 =item next
 

--- a/t/URT/t/61_iterator.t
+++ b/t/URT/t/61_iterator.t
@@ -5,7 +5,7 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__)."/../..";
 use URT;
-use Test::More tests => 9;
+use Test::More tests => 10;
 
 my $dbh = &setup_classes_and_db();
 
@@ -107,6 +107,21 @@ subtest peek => sub {
 
     ok(! $iter->peek(), 'peek returns nothing after iter is exhausted');
     ok(! $iter->next(), 'next returns nothing after iter is exhausted');
+};
+
+subtest remaining => sub {
+    plan tests => 5;
+
+    my $iter = URT::Thing->create_iterator();
+    ok($iter, 'create iterator matching all objects');
+
+    ok($iter->next, 'Get first object');
+    my @remaining = $iter->remaining;
+    is(scalar(@remaining), 4, 'got all 4 remaining objects');
+
+    is($iter->next, undef, 'calling next() now returns undef');
+    @remaining = $iter->remaining;
+    is(scalar(@remaining), 0, 'remaining() returns 0 objects');
 };
 
 sub setup_classes_and_db {

--- a/t/URT/t/61_iterator.t
+++ b/t/URT/t/61_iterator.t
@@ -5,7 +5,7 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__)."/../..";
 use URT;
-use Test::More tests => 8;
+use Test::More tests => 9;
 
 my $dbh = &setup_classes_and_db();
 
@@ -80,6 +80,33 @@ subtest 'or-rule, 2 ways to match the same object' => sub {
     }
     is(scalar(@objs), 1, 'Got one object back from the iterstor');
     is_deeply( [ map { $_->id } @objs], [2], 'Gor the right object ID from the iterator');
+};
+
+subtest peek => sub {
+    plan tests => 8;
+
+    # there are 3 Joes
+    my $iter = URT::Thing->create_iterator(name => 'Joe');
+    my $o1 = $iter->peek;
+    ok($o1, 'peek');
+
+    my $o2 = $iter->peek;
+    is($o1, $o2, 'peek again returns the same obj');
+
+    $o2 = $iter->next();
+    is($o1, $o2, 'next() returns the same obj, again');
+
+    $o2 = $iter->peek();
+    isnt($o1, $o2, 'peek after next() returns a different object');
+
+    my $o3 = $iter->next();
+    is($o2, $o3, 'next() after peek returns the same object');
+
+    $o3 = $iter->next();
+    ok($o3, 'next() returns 3rd object');
+
+    ok(! $iter->peek(), 'peek returns nothing after iter is exhausted');
+    ok(! $iter->next(), 'next returns nothing after iter is exhausted');
 };
 
 sub setup_classes_and_db {

--- a/t/URT/t/61_iterator.t
+++ b/t/URT/t/61_iterator.t
@@ -5,7 +5,7 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__)."/../..";
 use URT;
-use Test::More tests => 11;
+use Test::More tests => 12;
 
 my $dbh = &setup_classes_and_db();
 
@@ -138,6 +138,20 @@ subtest create_for_list => sub {
 
     my @objs = $iter->remaining;
     is_deeply(\@objs, \@expected, 'got back all the objects');
+};
+
+subtest map => sub {
+    plan tests => 3;
+
+    my $original_iter = URT::Thing->create_iterator(name => 'Bob');
+    ok($original_iter, 'Create iterator for all Bob');
+
+    my $names_iter = $original_iter->map(sub { $_->name });
+    ok($names_iter, 'Create mapping iterator returning names');
+
+    is_deeply([qw( Bob Bob )],
+              [ $names_iter->remaining ],
+              'all values from mapping iterator');
 };
 
 sub setup_classes_and_db {

--- a/t/URT/t/61_iterator.t
+++ b/t/URT/t/61_iterator.t
@@ -5,7 +5,7 @@ use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
 use lib File::Basename::dirname(__FILE__)."/../..";
 use URT;
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 my $dbh = &setup_classes_and_db();
 
@@ -122,6 +122,22 @@ subtest remaining => sub {
     is($iter->next, undef, 'calling next() now returns undef');
     @remaining = $iter->remaining;
     is(scalar(@remaining), 0, 'remaining() returns 0 objects');
+};
+
+subtest create_for_list => sub {
+    plan tests => 2;
+
+    my @expected = (
+            URT::Thing->get(2),
+            0,
+            1,
+            URT::Thing->get(6),
+        );
+    my $iter = UR::Object::Iterator->create_for_list(@expected);
+    ok($iter, 'created iterator');
+
+    my @objs = $iter->remaining;
+    is_deeply(\@objs, \@expected, 'got back all the objects');
 };
 
 sub setup_classes_and_db {


### PR DESCRIPTION
This branch adds new capabilities to Iterators
* The main Iterator API is moved up to UR::Iterator, and it can iterate non-object data
* You can create an iterator out of a list of things (```create_for_list()```)
* Create an iterator from another iterator and a transformation sub (```map()```)
* ```peek()``` at the next object without pulling it off of the iterator
* ```remaining()``` removes the list of all the thing left waiting on the iterator and returns that list