### PR TITLE
PG: The COLLATE must come before the DESC in the ORDER BY.

### DIFF
--- a/lib/UR/DataSource/Pg.pm
+++ b/lib/UR/DataSource/Pg.pm
@@ -222,13 +222,19 @@ sub cast_for_data_conversion {
 sub _resolve_order_by_clause_for_column {
     my($self, $column_name, $query_plan, $property_meta) = @_;
 
-    my $column_clause = $self->SUPER::_resolve_order_by_clause_for_column($column_name, $query_plan);
+    my $column_clause = $column_name;
 
     my $is_text_type = $property_meta->is_text;
     if ($is_text_type) {
         # Tell the DB to sort the same order as Perl's cmp
         $column_clause .= q( COLLATE "C");
     }
+
+    my $is_desc = $query_plan->order_by_column_is_descending($column_name);
+    if ($is_desc) {
+        $column_clause .= q( DESC);
+    }
+
     return $column_clause;
 }
 

--- a/t/URT/t/04c_postresql_type_coercion.t
+++ b/t/URT/t/04c_postresql_type_coercion.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
@@ -63,3 +63,6 @@ is(get_sql(sub { URT::A->get('some_event_time like' => '1970-01-01%') }),
     q{select A.a_id, A.creation_date, A.some_event_time from A where to_char(A.some_event_time, 'YYYY-MM-DD HH24:MI:SS.US') like ? escape E'\\\\' order by A.a_id COLLATE "C"},
     "to_char coercion on Timestamp column");
 
+is(get_sql(sub { URT::A->get('some_event_time like' => '1970-01-01%', -order => ['-id']) }),
+    q{select A.a_id, A.creation_date, A.some_event_time from A where to_char(A.some_event_time, 'YYYY-MM-DD HH24:MI:SS.US') like ? escape E'\\\\' order by A.a_id COLLATE "C" DESC},
+    "to_char coercion on Timestamp column");


### PR DESCRIPTION
I recently tried to use `-order => ['-some_text_column']` in a `get()`, which led to a syntax error being reported by Postgres similar to:

```
order by some_table.some_text_column DESC COLLATE "C", some_table.some_other_column COLLATE "C"
ERROR:  syntax error at or near "COLLATE"
LINE 12: ...table.some_text_column DESC COLLATE "C...
```

This pulls `DESC`-adding logic down from the superclass so the `COLLATE` can be added first.