### PR TITLE
Don't return deleted changes from get_changes().

### DIFF
--- a/lib/UR/Context/Transaction.pm
+++ b/lib/UR/Context/Transaction.pm
@@ -127,7 +127,7 @@ sub get_changes {
         @changes = UR::Change->get(id => \@changes, @_)
     }
     else {
-        return @changes;
+        return grep { !$_->isa('UR::DeletedRef') } @changes;
     }
 }
 


### PR DESCRIPTION
I'm running into an issue where attempting to commit() a transaction fails because the change_log has some deleted changes in range of the `begin_point`..`end_point`.  I'm not sure why they're there, but it seems like a deleted change is not a change we should be worried about!

Maybe there's a better way to handle this?  (Should deleted changes be removed from the log altogether? Is it bad that they snuck in in the first place and this is covering up a larger problem?)