### PR TITLE
Lister: Also use the _object_property_to_string helper in the XML style.

### DIFF
--- a/lib/UR/Object/Command/List/Style.pm
+++ b/lib/UR/Object/Command/List/Style.pm
@@ -215,7 +215,7 @@ sub format_and_print{
 
              my $property_node = $object_node->addChild ($doc->createElement($property));
 
-             my @items = $object->$property;
+             my @items = $self->_object_property_to_string($object, $property);
 
              my $reftype = ref $items[0];
 


### PR DESCRIPTION
A user complained about the XML style not working in a lister.  This turned out to be because they were using a `--show` item with a `.` in it.  This change lets the wider set of expressions work in the XML style.