### PR TITLE
fix some spelling mistakes

### DIFF
--- a/lib/UR/BoolExpr/Template/PropertyComparison/Like.pm
+++ b/lib/UR/BoolExpr/Template/PropertyComparison/Like.pm
@@ -37,7 +37,7 @@ UR::BoolExpr::Template::PropertyComparison::Like - perform an SQL-ish like test
 
 =head1 DESCRIPTION
 
-The input test value is assummed to be an SQL 'like' value, where '_'
+The input test value is assumed to be an SQL 'like' value, where '_'
 represents a one character wildcard, and '%' means a 0 or more character
 wildcard.  It gets converted to a perl regular expression and used to match
 against an object's properties.

--- a/lib/UR/BoolExpr/Template/PropertyComparison/NotLike.pm
+++ b/lib/UR/BoolExpr/Template/PropertyComparison/NotLike.pm
@@ -36,7 +36,7 @@ UR::BoolExpr::Template::PropertyComparison::NotLike - perform a negated SQL-ish 
 
 =head1 DESCRIPTION
 
-The input test value is assummed to be an SQL 'like' value, where '_'
+The input test value is assumed to be an SQL 'like' value, where '_'
 represents a one character wildcard, and '%' means a 0 or more character
 wildcard.  It gets converted to a perl regular expression and used in a
 negated match against an object's properties

--- a/lib/UR/Context/ImportIterator.pm
+++ b/lib/UR/Context/ImportIterator.pm
@@ -638,7 +638,7 @@ sub _create_import_iterator_for_underlying_context {
                         # The last time this happened, it was because a get() was done on an abstract
                         # base class with only 'id' as a param.  When the subclassified rule was
                         # turned into SQL in UR::DataSource::QueryPlan()
-                        # it removed that one 'id' filter, since it assummed any class with more than
+                        # it removed that one 'id' filter, since it assumed any class with more than
                         # one ID property (usually classes have a named whatever_id property, and an alias 'id'
                         # property) will have a rule that covered both ID properties
                         Carp::carp("Leftover objects in subordinate iterator for $class.  This shouldn't happen, but it's not fatal...");

--- a/lib/UR/DataSource/File.pm
+++ b/lib/UR/DataSource/File.pm
@@ -995,7 +995,7 @@ sub _sync_database {
     my $changed_objects = delete $params{changed_objects};
 
 
-    # We're going to assumme all the passed-in objects are of the same class *gulp*
+    # We're going to assume all the passed-in objects are of the same class *gulp*
     my $class_name = $changed_objects->[0]->class;
     my $class_meta = UR::Object::Type->get(class_name => $class_name);
     my %column_name_to_property_meta = map { $_->column_name => $_ }
@@ -1321,7 +1321,7 @@ is no default.
 If the data file is sorted in some way, sort_order() should return a listref of column names (which must
 exist in column_order()) by which the file is sorted.  This gives the system a hint about how the file
 is structured, and is able to make shortcuts when reading the file to speed up data access.  The default
-is to assumme the file is not sorted.
+is to assume the file is not sorted.
 
 =back
 

--- a/lib/UR/DataSource/RDBMS.pm
+++ b/lib/UR/DataSource/RDBMS.pm
@@ -1353,7 +1353,7 @@ sub _resolve_table_name_for_class_name {
 
 # For when there's no metaDB info for a class' table, it walks up the
 # ancestry of the class, and uses the ID properties to get the column
-# names, and assummes they must be the table primary keys.
+# names, and assumes they must be the table primary keys.
 #
 # From there, it guesses the sequence name
 sub _resolve_sequence_name_from_class_id_properties {

--- a/lib/UR/Namespace/Command/Define/Datasource.pm
+++ b/lib/UR/Namespace/Command/Define/Datasource.pm
@@ -65,7 +65,7 @@ sub dsname {
     my $dsname = $self->__dsname;
     unless ($dsname) {
         my $dsid = $self->__dsid;
-        # assumme the name is the last portion of the class name
+        # assume the name is the last portion of the class name
         $dsname = (split(/::/,$dsid))[-1];
         $self->__dsname($dsname);
     }

--- a/lib/UR/Object/Property.pm
+++ b/lib/UR/Object/Property.pm
@@ -475,7 +475,7 @@ is how one-to-one relationships are implemented.
 =item via property
 
 When a class has some object accessor property, and it is helpful for an
-object to assumme the value of the remote class's properties, you can set 
+object to assume the value of the remote class's properties, you can set
 up a 'via' property.  In the example above, an object of this class 
 gets the value of its 'bar' property via the 'other' object it's linked
 to, from that object's 'bar' property.

--- a/lib/UR/Role.pm
+++ b/lib/UR/Role.pm
@@ -137,7 +137,7 @@ many class-meta attributes such as 'id_generator', 'valid_signals', and 'doc'.
 
 Roles may implement operator overloading via the 'use overload' mechanism.
 
-Roles also have unique atributes to declare restrictions on their use.
+Roles also have unique attributes to declare restrictions on their use.
 
 =over 4
 

--- a/t/URT/t/55_on_the_fly_metadb.t
+++ b/t/URT/t/55_on_the_fly_metadb.t
@@ -11,7 +11,7 @@ use Sub::Install;
 use strict;
 use warnings;
 
-# This test assummes the storage DB schema already exists, but that the metaDB has
+# This test assumes the storage DB schema already exists, but that the metaDB has
 # no record of it.  
 
 plan tests => 20;

--- a/t/URT/t/55b_partial_metada_data.t
+++ b/t/URT/t/55b_partial_metada_data.t
@@ -9,7 +9,7 @@ use URT;
 use strict;
 use warnings;
 
-# This test assummes the storage DB schema already exists, but that the metaDB has
+# This test assumes the storage DB schema already exists, but that the metaDB has
 # incomplete or outdated info about it, though the class and actual DB schema do match
 
 plan tests => 26;


### PR DESCRIPTION

In Debian we are currently applying the following patch to UR.
We thought you might be interested in it too.

    Description: fix some spelling mistakes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-04-07
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libur-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
