### PR TITLE
Fix test failures when cwd contains regexp metacharacters

### DIFF
--- a/lib/Command/SubCommandFactory.pm
+++ b/lib/Command/SubCommandFactory.pm
@@ -61,7 +61,7 @@ sub _build_sub_command_mapping {
     my @target_class_names;
     for my $target_path (@target_paths) { 
         my $target = $target_path;
-        $target =~ s#$base_path\/$ref_path/##; 
+        $target =~ s#\Q$base_path\E\/$ref_path/##;
         $target =~ s/\.pm//;
 
         my $target_base_class = $class->_target_base_class;

--- a/lib/UR/Namespace/Command/Sys/ClassBrowser.pm
+++ b/lib/UR/Namespace/Command/Sys/ClassBrowser.pm
@@ -200,7 +200,7 @@ sub _generate_class_name_cache {
     my $cwd = Cwd::getcwd . '/';
     my $namespace_meta = $namespace->__meta__;
     my $namespace_dir = $namespace_meta->module_directory;
-    (my $path = $namespace_meta->module_path) =~ s/^$cwd//;
+    (my $path = $namespace_meta->module_path) =~ s/^\Q$cwd\E//;
     my $by_class_name = {  $namespace => {
                                 name  => $namespace,
                                 is    => $namespace_meta->is,
@@ -226,7 +226,7 @@ sub _class_name_cache_data_for_class_name {
     }
     my $namespace_dir = $class_meta->namespace->__meta__->module_directory;
     my $module_path = $class_meta->module_path;
-    (my $relpath = $module_path) =~ s/^$namespace_dir//;
+    (my $relpath = $module_path) =~ s/^\Q$namespace_dir\E//;
     return {
         name    => $class_meta->class_name,
         relpath => $relpath,


### PR DESCRIPTION
t/URT/t/70d_command_sub_command_factory.t and t/class_browser/internal.t fail without this when run in a directory containing regexp metacharacters like a plus ('+').

Bug-Debian: https://bugs.debian.org/901241