### PR TITLE
Fix broken JSON-related test

### DIFF
--- a/lib/UR/Object/Property.pm
+++ b/lib/UR/Object/Property.pm
@@ -99,7 +99,10 @@ sub _convert_data_type_for_source_class_to_final_class {
         else {
             my ($ns_value_class, $ur_value_class);
 
-            if ($ns and $ns->can("get")) {
+            if ($ns
+                and $ns ne 'UR' and $ns ne 'URT'
+                and $ns->can("get")
+            ) {
                 $ns_value_class = $ns . '::Value::' . $foreign_class;
                 if ($ns_value_class->can('__meta__')) {
                     $final_class = $ns_value_class;
@@ -108,13 +111,11 @@ sub _convert_data_type_for_source_class_to_final_class {
 
             if (!$final_class) {
                 $ur_value_class = 'UR::Value::' . $foreign_class;
-                if ($ur_value_class->can('__meta__')) {
-                    $final_class = $ur_value_class;
-                }
-            }
-            if (!$final_class) {
-                $ur_value_class = 'UR::Value::' . ucfirst(lc($foreign_class));
-                if ($ur_value_class->can('__meta__')) {
+                my $normalized_ur_value_class = 'UR::Value::' . ucfirst(lc($foreign_class));
+                if ($normalized_ur_value_class->can('__meta__')) {
+                    $final_class = $normalized_ur_value_class;
+
+                } elsif ($ur_value_class->can('__meta__')) {
                     $final_class = $ur_value_class;
                 }
             }

--- a/lib/UR/Object/View/Default/Json.pm
+++ b/lib/UR/Object/View/Default/Json.pm
@@ -24,6 +24,7 @@ sub _json {
 
     $json = JSON->new;
     foreach my $opt ( @{ $self->encode_options } ) {
+        local $@;
         eval { $json = $json->$opt; };
         if ($@) {
             Carp::croak("Can't initialize JSON object for encoding.  Calling method $opt from encode_options died: $@");

--- a/lib/UR/Value/Number.pm
+++ b/lib/UR/Value/Number.pm
@@ -9,4 +9,8 @@ UR::Object::Type->define(
     is => ['UR::Value'],
 );
 
+sub __display_name__ {
+    shift->id + 0;
+}
+
 1;

--- a/t/URT/t/63c_view_with_subviews.t
+++ b/t/URT/t/63c_view_with_subviews.t
@@ -45,6 +45,7 @@ is($age2->__display_name__, "22 yrs", "$age2 has id " . $age2->id . " and displa
 ## entity data types
 class Acme::Animal {
     has => [
+        id      => { is => 'Integer' },
         name    => { is => 'Text' },
         age     => { is => 'Years' },
     ]

--- a/t/URT/t/63c_view_with_subviews.t.expected.cat_set.json
+++ b/t/URT/t/63c_view_with_subviews.t.expected.cat_set.json
@@ -2,10 +2,10 @@
    "id" : "Acme::Cat/And/owner_id/O:\u001dO:111\u001e",
    "members" : [
       {
-         "id" : "222"
+         "id" : 222
       },
       {
-         "id" : "333"
+         "id" : 333
       }
    ]
 }

--- a/t/URT/t/63c_view_with_subviews.t.expected.person.json
+++ b/t/URT/t/63c_view_with_subviews.t.expected.person.json
@@ -3,10 +3,10 @@
    "cats" : [
       {
          "age" : "2 yrs",
-         "fluf" : "11",
+         "fluf" : 11,
          "name" : "fluffy",
          "owner" : {
-            "id" : "111"
+            "id" : 111
          }
       },
       {
@@ -14,7 +14,7 @@
          "fluf" : "22 yrs",
          "name" : "nestor",
          "owner" : {
-            "id" : "111"
+            "id" : 111
          }
       }
    ],


### PR DESCRIPTION
The 63c_view_with_subviews.t test has been broken for a while.  Several PRs are blocked on this broken test, it's been brought up on the per5-porters and debian-bugs-dist mailing lists, and #142 was just filed recently, too.

The details are in a8c09a3, but the short story is that JSON::PP now seems to behave differently for some numbers depending on the version of perl.  This change forces `UR::Value::Number::__display_name__()` (used by the View renderers) to return a number, and changes the test accordingly.