### PR TITLE
Build dir metacharacters

### DIFF
--- a/lib/Command/DynamicSubCommands.pm
+++ b/lib/Command/DynamicSubCommands.pm
@@ -76,7 +76,7 @@ sub _build_all_sub_commands {
 
     my $full_ref_path = $base_path . '/' . $ref_path;
 
-    my @target_paths = glob("$full_ref_path/*.pm");
+    my @target_paths = glob("\Q$full_ref_path\E/*.pm");
 
     my @target_class_names;
     for my $target_path (@target_paths) {

--- a/lib/Command/SubCommandFactory.pm
+++ b/lib/Command/SubCommandFactory.pm
@@ -57,7 +57,7 @@ sub _build_sub_command_mapping {
     $ref_path =~ s/::/\//g;
     my $full_ref_path = $base_path . '/' . $ref_path;
 
-    my @target_paths = glob("$full_ref_path/*.pm");
+    my @target_paths = glob("\Q$full_ref_path\E/*.pm");
     my @target_class_names;
     for my $target_path (@target_paths) { 
         my $target = $target_path;

--- a/lib/Command/SubCommandFactory.pm
+++ b/lib/Command/SubCommandFactory.pm
@@ -61,7 +61,7 @@ sub _build_sub_command_mapping {
     my @target_class_names;
     for my $target_path (@target_paths) { 
         my $target = $target_path;
-        $target =~ s#$base_path\/$ref_path/##; 
+        $target =~ s#\Q$base_path\E\/$ref_path/##;
         $target =~ s/\.pm//;
 
         my $target_base_class = $class->_target_base_class;

--- a/lib/Command/Tree.pm
+++ b/lib/Command/Tree.pm
@@ -369,7 +369,7 @@ sub _build_sub_command_mapping {
 
             # find My::Foo::Command::*
             if (-d $subdir_full_path) {
-                my @files = glob($subdir_full_path . '/*');
+                my @files = glob("\Q${subdir_full_path}/*");
                 for my $file (@files) {
                     my $basename = basename($file);
                     $basename =~ s/.pm$// or next;
@@ -394,7 +394,7 @@ sub _build_sub_command_mapping {
             # find My::Foo::*::Command
             $subdir_full_path = $lib . '/' . $subdir2;
             my $pattern = $subdir_full_path . '/*/Command.pm';
-            my @paths = glob($pattern);
+            my @paths = glob("\Q$pattern\E");
             for my $file (@paths) {
                 next unless defined $file;
                 next unless length $file;

--- a/lib/Command/V1.pm
+++ b/lib/Command/V1.pm
@@ -1275,7 +1275,7 @@ sub sub_command_classes {
     return unless @paths;
     @paths =
         grep { s/\.pm$// }
-        map { glob("$_/*") }
+        map { glob("\Q$_\E/*") }
         grep { -d $_ }
         grep { defined($_) and length($_) }
         @paths;

--- a/lib/Command/V2Deprecated.pm
+++ b/lib/Command/V2Deprecated.pm
@@ -181,7 +181,7 @@ sub _build_sub_command_mapping {
         for my $lib (@INC) {
             my $subdir_full_path = $lib . '/' . $subdir;
             next unless -d $subdir_full_path;
-            my @files = glob($subdir_full_path . '/*');
+            my @files = glob("\Q${subdir_full_path}\E/*");
             next unless @files;
             for my $file (@files) {
                 my $basename = basename($file);

--- a/lib/UR.pm
+++ b/lib/UR.pm
@@ -42,7 +42,7 @@ for my $e (keys %ENV) {
     if ($@) {
         my $path = __FILE__;
         $path =~ s/.pm$//;
-        my @files = glob($path . '/Env/*');
+        my @files = glob("\Q${path}\E/Env/*");
         my @vars = map { /UR\/Env\/(.*).pm/; $1 } @files;
         print STDERR "Environment variable $e set to $ENV{$e} but there were errors using UR::Env::$e:\n"
         . "Available variables:\n\t"

--- a/lib/UR/ModuleBase.pm
+++ b/lib/UR/ModuleBase.pm
@@ -804,7 +804,7 @@ sub _carp_sprintf {
         local $SIG{__WARN__} = sub {
             my $msg = $_[0];
             my ($filename, $line) = (caller)[1, 2];
-            my $short_msg = ($msg =~ /(.*) at $filename line $line./)[0];
+            my $short_msg = ($msg =~ /(.*) at \Q$filename\E line $line./)[0];
             $warn_msg = ($short_msg || $msg);
         };
         $formatted_string = sprintf($format, @list);

--- a/lib/UR/Namespace.pm
+++ b/lib/UR/Namespace.pm
@@ -100,7 +100,7 @@ sub get_data_sources
         foreach my $inc ( @main::INC ) {
             my $path = join('/', $inc,$namespace_name,'DataSource');
             if (-d $path) {
-                foreach ( glob($path . '/*.pm') ) { 
+                foreach ( glob("\Q${path}\E/*.pm") ) {
                     my($module_name) = m/DataSource\/([^\/]+)\.pm$/;
                     my $ds_class_name = $namespace_name . '::DataSource::' . $module_name;
                     $found{$ds_class_name} = 1;

--- a/lib/UR/Namespace/Command/Base.pm
+++ b/lib/UR/Namespace/Command/Base.pm
@@ -211,7 +211,7 @@ sub _class_names_in_tree {
     my @class_names;
     for my $module (@modules) {
         my $class = $module;
-        $class =~ s/^$lib_path\///;
+        $class =~ s/^\Q$lib_path\E\///;
         $class =~ s/\//::/g;
         $class =~ s/\.pm$//;
 

--- a/lib/UR/Namespace/Command/Sys/ClassBrowser.pm
+++ b/lib/UR/Namespace/Command/Sys/ClassBrowser.pm
@@ -200,7 +200,7 @@ sub _generate_class_name_cache {
     my $cwd = Cwd::getcwd . '/';
     my $namespace_meta = $namespace->__meta__;
     my $namespace_dir = $namespace_meta->module_directory;
-    (my $path = $namespace_meta->module_path) =~ s/^$cwd//;
+    (my $path = $namespace_meta->module_path) =~ s/^\Q$cwd\E//;
     my $by_class_name = {  $namespace => {
                                 name  => $namespace,
                                 is    => $namespace_meta->is,
@@ -226,7 +226,7 @@ sub _class_name_cache_data_for_class_name {
     }
     my $namespace_dir = $class_meta->namespace->__meta__->module_directory;
     my $module_path = $class_meta->module_path;
-    (my $relpath = $module_path) =~ s/^$namespace_dir//;
+    (my $relpath = $module_path) =~ s/^\Q$namespace_dir\E//;
     return {
         name    => $class_meta->class_name,
         relpath => $relpath,

--- a/lib/UR/Util.pm
+++ b/lib/UR/Util.pm
@@ -38,8 +38,8 @@ sub used_libs {
     for my $inc (@INC) {
         $inc =~ s/\/+$//;
         my $abs_inc = Cwd::abs_path($inc) || $inc; # should already be expanded by UR.pm
-        next if (grep { $_ =~ /^$abs_inc$/ } @compiled_inc);
-        next if (grep { $_ =~ /^$abs_inc$/ } @perl5lib);
+        next if (grep { $_ =~ /^\Q$abs_inc\E$/ } @compiled_inc);
+        next if (grep { $_ =~ /^\Q$abs_inc\E$/ } @perl5lib);
         next if ((File::Spec->splitdir($inc))[-1] eq $Config{archname});
         push @extra, $inc;
     }

--- a/t/CmdTest/t/01-mutual-resolution-via-to.t
+++ b/t/CmdTest/t/01-mutual-resolution-via-to.t
@@ -24,11 +24,11 @@ my $path = $INC{"CmdTest/C3.pm"};
 ok($path, "found path to test module")
     or die "cannot continue!";
 
-my $result1 = `$^X $path --thing=two`;
+my $result1 = `$^X \Q$path\E --thing=two`;
 chomp $result1;
 is($result1, "thing_id is 222", "specifying an object automatically specifies its indirect value");
 
-my $result2 = `$^X $path --thing-name=two`;
+my $result2 = `$^X \Q$path\E --thing-name=two`;
 chomp $result2;
 is($result2, "thing_id is 222", "specifying an indirect value automatically sets the value it is via");
 


### PR DESCRIPTION
Fixes tests that break when parts of the path contain metachars.  This PR includes and supersedes #141.

Found these by setting the parent dir to the checkout to:
* ```+```
* ```*```
* ```\```
* ```$```
* ```^```
* ```?```
