### PR TITLE
Autoload fix

### DIFF
--- a/lib/UR/Service/RPC/Executer.pm
+++ b/lib/UR/Service/RPC/Executer.pm
@@ -78,19 +78,25 @@ sub execute {
 
 
         my $method_name = join('::',$target_class, $method);
-        local $@;
-        if ($wantarray) {
-            my @retval;
-            eval { no strict 'refs'; @retval = &{$method_name}(@arglist); };
-            $resp_msg_args{'return_values'} = \@retval unless ($@);
-        } elsif (defined $wantarray) {
-            my $retval;
-            eval { no strict 'refs'; no warnings; $retval = &{$method_name}(@arglist); };
-            $resp_msg_args{'return_values'} = [$retval] unless ($@);
+        if (! $target_class->can($method)) {
+            $resp_msg_args{exception} =
+                qq(Can't locate object method "$method" via package "$target_class" (perhaps you forgot to load "$target_class"?));
+
         } else {
-            eval { no strict 'refs'; &{$method_name}(@arglist); };
+            local $@;
+            if ($wantarray) {
+                my @retval;
+                eval { no strict 'refs'; @retval = &{$method_name}(@arglist); };
+                $resp_msg_args{return_values} = \@retval unless ($@);
+            } elsif (defined $wantarray) {
+                my $retval;
+                eval { no strict 'refs'; no warnings; $retval = &{$method_name}(@arglist); };
+                $resp_msg_args{return_values} = [$retval] unless ($@);
+            } else {
+                eval { no strict 'refs'; &{$method_name}(@arglist); };
+            }
+            $resp_msg_args{exception} = $@ if $@;
         }
-        $resp_msg_args{'exception'} = $@ if $@;
         $response = UR::Service::RPC::Message->create(%resp_msg_args);
 
     } else {

--- a/lib/UR/Service/RPC/Executer.pm
+++ b/lib/UR/Service/RPC/Executer.pm
@@ -78,6 +78,7 @@ sub execute {
 
 
         my $method_name = join('::',$target_class, $method);
+        local $@;
         if ($wantarray) {
             my @retval;
             eval { no strict 'refs'; @retval = &{$method_name}(@arglist); };

--- a/t/URT/t/41_rpc_basic.t
+++ b/t/URT/t/41_rpc_basic.t
@@ -100,8 +100,9 @@ $resp = UR::Service::RPC::Message->recv($to_server,1);
 ok($resp, 'Got a response message back from the server');
 @return_values = $resp->return_value_list;
 is(scalar(@return_values), 0, 'Response return value is correctly empty');
-ok($resp->exception =~ m/(Can't locate object method|Undefined sub).*some_undefined_function/,
-   'Response exception correctly reflects calling an undefined function');
+like($resp->exception,
+    qr/(Can't locate object method|Undefined sub).*some_undefined_function/,
+    'Response exception correctly reflects calling an undefined function');
 
 
 

--- a/t/URT/t/42_rpc_between_processes.t
+++ b/t/URT/t/42_rpc_between_processes.t
@@ -123,8 +123,9 @@ $resp = UR::Service::RPC::Message->recv($to_server,1);
 ok($resp, 'Got a response message back from the server');
 @return_values = $resp->return_value_list;
 is(scalar(@return_values), 0, 'Response return value is correctly empty');
-ok($resp->exception =~ m/(Can't locate object method|Undefined sub).*some_undefined_function/,
-   'Response exception correctly reflects calling an undefined function');
+like($resp->exception,
+    qr/(Can't locate object method|Undefined sub).*some_undefined_function/,
+    'Response exception correctly reflects calling an undefined function');
 
 my $string = 'a string with some words';
 my $pattern = '(\w+) (\w+) (\w+)';


### PR DESCRIPTION
Perl 5.28 removes a deprecated feature where AUTOLOAD used to get called even for non-method calls.  The fix is to check if the class can() the requested method before calling it, and generating an exception that looks like the Perl-native exception if not.

This fixes #136