### PR TITLE
Abort if we ran out of directory parts.

### DIFF
--- a/lib/above.pm
+++ b/lib/above.pm
@@ -65,6 +65,7 @@ sub use_package {
     my $dev = _dev($cwd);
     my $abort_crawl = sub {
         my @parts = @_;
+        return 1 if (@parts == 0); # nothing left to try
         return 1 if (@parts == 1 && $parts[0] eq ''); # hit root dir
         my $path = File::Spec->join(@parts);
         return !($xdev || _dev($path) == $dev); # crossed device


### PR DESCRIPTION
When the cwd is invalid, `getcwd()` can return a single name instead of a full path.  Then there's no leading slash to split on, so we can run out of parts without finding an empty string.  In this case `above.pm` was infinitely looping while spamming warnings like:
```
Use of uninitialized value $path in stat at /.../above.pm line 43.
Use of uninitialized value $dev in numeric eq (==) at /.../above.pm line 70.
Use of uninitialized value in numeric eq (==) at /.../above.pm line 70.
```
This adds an additional termination condition when there are no parts left.
