### PR TITLE
Fix typo in POD

### DIFF
--- a/lib/UR/Manual/Cookbook.pod
+++ b/lib/UR/Manual/Cookbook.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-UR::Manual::Cookbook - Recepies for getting things working
+UR::Manual::Cookbook - Recipes for getting things working
 
 =head1 Database Changes
 


### PR DESCRIPTION
"Recepies" -> "Recipes"