### PR TITLE
Fix test failure with newer (DBD::)SQLite

### DIFF
--- a/t/URT/t/04a_sqlite.t
+++ b/t/URT/t/04a_sqlite.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 80;
+use Test::Deep;
 
 use File::Basename;
 use lib File::Basename::dirname(__FILE__)."/../../../lib";
@@ -37,7 +38,7 @@ sub test_column_details {
 
     my @expected = ( { TABLE_NAME  => 'inline',
                        COLUMN_NAME => 'id',
-                       DATA_TYPE   => 'integer',
+                       DATA_TYPE   => re(qr/^integer$/i),
                        COLUMN_SIZE => undef,
                        NULLABLE    => 1,
                        COLUMN_DEF  => undef,
@@ -50,7 +51,7 @@ sub test_column_details {
                        COLUMN_DEF  => 'some name',
                      },
                   );
-    is_deeply(\@results,
+    cmp_deeply(\@results,
               \@expected,
                'column details for table inline are correct');
 }


### PR DESCRIPTION

In Debian we are currently applying the following patch to UR.
We thought you might be interested in it too.

    Description: Fix test failure with newer (DBD::)SQLite
     ```
     t/URT/t/04a_sqlite.t
     â¦
     not ok 80 - column details for table inline are correct
    
     #   Failed test 'column details for table inline are correct'
     #   at t/URT/t/04a_sqlite.t line 53.
     #     Structures begin differing at:
     #          $got->[0]{DATA_TYPE} = 'INTEGER'
     #     $expected->[0]{DATA_TYPE} = 'integer'
     # Looks like you failed 1 test of 80.
     Dubious, test returned 1 (wstat 256, 0x100)
     Failed 1/80 subtests 
     ```
     Use Test::Deep's cmp_deeply to be able to check against a case-insenstive regexp.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2022-01-17
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libur-perl/raw/master/debian/patches/sqlite-case-insensitve.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
